### PR TITLE
feat: parse Pleco exports, dictionary providers, and pinyin converter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ Thumbs.db
 
 # Large local data files
 Chinese.txt
+flash.txt
 
 # Local selection dump
 SelectedNotes.txt

--- a/zh-learn-cli/src/main/java/com/zhlearn/cli/MainCommand.java
+++ b/zh-learn-cli/src/main/java/com/zhlearn/cli/MainCommand.java
@@ -18,7 +18,7 @@ import picocli.CommandLine.ScopeType;
 @Command(name = "zh-learn",
         mixinStandardHelpOptions = true,
         version = "1.0.0-SNAPSHOT",
-        subcommands = { WordCommand.class, ProvidersCommand.class, ParseAnkiCommand.class, AudioCommand.class, picocli.CommandLine.HelpCommand.class },
+        subcommands = { WordCommand.class, ProvidersCommand.class, ParseAnkiCommand.class, ParsePlecoCommand.class, AudioCommand.class, picocli.CommandLine.HelpCommand.class },
         scope = ScopeType.INHERIT)
 public class MainCommand implements Runnable {
 

--- a/zh-learn-cli/src/main/java/com/zhlearn/cli/ParsePlecoCommand.java
+++ b/zh-learn-cli/src/main/java/com/zhlearn/cli/ParsePlecoCommand.java
@@ -1,0 +1,219 @@
+package com.zhlearn.cli;
+
+import com.zhlearn.application.service.WordAnalysisServiceImpl;
+import com.zhlearn.domain.model.Hanzi;
+import com.zhlearn.domain.model.ProviderConfiguration;
+import com.zhlearn.domain.model.WordAnalysis;
+import com.zhlearn.infrastructure.dictionary.PlecoExportDictionary;
+import com.zhlearn.infrastructure.dictionary.DictionaryDefinitionProvider;
+import com.zhlearn.infrastructure.dictionary.DictionaryExplanationProvider;
+import com.zhlearn.infrastructure.dictionary.DictionaryStructuralDecompositionProvider;
+import com.zhlearn.infrastructure.pleco.PlecoEntry;
+import com.zhlearn.infrastructure.pleco.PlecoExportParser;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+/**
+ * CLI command to parse Pleco export files and process all words through the analysis pipeline.
+ * Processes each word found in the export like the existing "word" command.
+ */
+@Command(
+    name = "parse-pleco",
+    description = "Parse Pleco export file and analyze all Chinese words"
+)
+public class ParsePlecoCommand implements Runnable {
+    
+    @Parameters(index = "0", description = "Path to the Pleco export file (TSV format)")
+    private String filePath;
+    
+    @Option(names = {"--provider"}, description = "Set default provider for all services (default: pinyin4j for pinyin, dummy for others). Available: dummy, pinyin4j, gpt-5-nano, deepseek-chat")
+    private String defaultProvider = "dummy";
+    
+    @Option(names = {"--pinyin-provider"}, description = "Set specific provider for pinyin. Available: pinyin4j, dummy")
+    private String pinyinProvider;
+    
+    @Option(names = {"--definition-provider"}, description = "Set specific provider for definition. Available: dummy")
+    private String definitionProvider;
+    
+    @Option(names = {"--decomposition-provider"}, description = "Set specific provider for structural decomposition. Available: dummy, gpt-5-nano, deepseek-chat")
+    private String decompositionProvider;
+    
+    @Option(names = {"--example-provider"}, description = "Set specific provider for examples. Available: dummy, gpt-5-nano, deepseek-chat")
+    private String exampleProvider;
+    
+    @Option(names = {"--explanation-provider"}, description = "Set specific provider for explanation. Available: dummy, gpt-5-nano, deepseek-chat")
+    private String explanationProvider;
+    
+    @Option(names = {"--raw", "--raw-output"}, description = "Display raw HTML content instead of formatted output")
+    private boolean rawOutput = false;
+    
+    @Option(names = {"--limit"}, description = "Limit the number of words to process (default: all)")
+    private Integer limit;
+
+    @picocli.CommandLine.ParentCommand
+    private MainCommand parent;
+    
+    @Override
+    public void run() {
+        try {
+            Path path = Paths.get(filePath);
+            PlecoExportParser parser = new PlecoExportParser();
+            List<PlecoEntry> entries = parser.parseFile(path);
+            
+            System.out.println("Successfully parsed " + entries.size() + " entries from: " + filePath);
+            System.out.println();
+            
+            // Create dictionary for any dictionary-based providers
+            PlecoExportDictionary dictionary = new PlecoExportDictionary(entries);
+
+            // Register dictionary-backed providers so users can opt-in via --*-provider flags
+            var registry = parent.getProviderRegistry();
+            registry.registerDefinitionProvider(new DictionaryDefinitionProvider(dictionary));
+            registry.registerExplanationProvider(new DictionaryExplanationProvider(dictionary));
+            registry.registerStructuralDecompositionProvider(new DictionaryStructuralDecompositionProvider(dictionary));
+            
+            // Set up word analysis service
+            WordAnalysisServiceImpl wordAnalysisService = new WordAnalysisServiceImpl(parent.getProviderRegistry());
+            
+            ProviderConfiguration config = new ProviderConfiguration(
+                defaultProvider,
+                pinyinProvider,
+                definitionProvider,
+                decompositionProvider,
+                exampleProvider,
+                explanationProvider,
+                null // audio provider (default)
+            );
+            
+            // Process each word through the analysis pipeline
+            int processedCount = 0;
+            int maxToProcess = limit != null ? limit : entries.size();
+            
+            for (PlecoEntry entry : entries) {
+                if (processedCount >= maxToProcess) {
+                    break;
+                }
+                
+                try {
+                    Hanzi word = new Hanzi(entry.hanzi());
+                    WordAnalysis analysis = wordAnalysisService.getCompleteAnalysis(word, config);
+                    
+                    System.out.println("=".repeat(80));
+                    System.out.println("Word " + (processedCount + 1) + "/" + Math.min(maxToProcess, entries.size()));
+                    System.out.println("=".repeat(80));
+                    
+                    if (rawOutput) {
+                        printAnalysisRaw(analysis, entry);
+                    } else {
+                        printAnalysisFormatted(analysis, entry);
+                    }
+                    
+                    System.out.println();
+                    processedCount++;
+                    
+                } catch (Exception e) {
+                    System.err.println("Error analyzing word '" + entry.hanzi() + "': " + e.getMessage());
+                    // Continue with next word
+                }
+            }
+            
+            System.out.println("Processed " + processedCount + " words successfully.");
+            
+        } catch (Exception e) {
+            System.err.println("Error parsing Pleco file: " + e.getMessage());
+            System.exit(1);
+        }
+    }
+    
+    private void printAnalysisFormatted(WordAnalysis analysis, PlecoEntry originalEntry) {
+        int width = TerminalFormatter.getTerminalWidth();
+        
+        // Main header with word and original Pleco pinyin
+        String wordContent = TerminalFormatter.formatChineseWord(analysis.word().characters(), analysis.pinyin().pinyin()) + "\n" +
+                            "Original Pleco pinyin: " + originalEntry.pinyin() + "\n" +
+                            TerminalFormatter.formatProvider("Default: " + analysis.providerName());
+        System.out.println(TerminalFormatter.createBox("Chinese Word", wordContent, width));
+        System.out.println();
+        
+        // Original Pleco definition
+        String plecoDefContent = originalEntry.definitionText() + "\n" +
+                                "Source: Pleco Export";
+        System.out.println(TerminalFormatter.createBox("Original Pleco Definition", plecoDefContent, width));
+        System.out.println();
+        
+        // Pinyin section
+        String pinyinContent = TerminalFormatter.formatChineseWord("拼音", analysis.pinyin().pinyin()) + "\n" +
+                              TerminalFormatter.formatProvider(analysis.pinyinProvider());
+        System.out.println(TerminalFormatter.createBox("Pinyin", pinyinContent, width));
+        System.out.println();
+        
+        // Definition section  
+        String defContent = TerminalFormatter.formatDefinition(analysis.definition().meaning(), analysis.definition().partOfSpeech()) + "\n" +
+                           TerminalFormatter.formatProvider(analysis.definitionProvider());
+        System.out.println(TerminalFormatter.createBox("Definition", defContent, width));
+        System.out.println();
+        
+        // Structural Decomposition section
+        String decompositionContent = TerminalFormatter.formatStructuralDecomposition(
+            analysis.structuralDecomposition().decomposition()) + "\n" +
+            TerminalFormatter.formatProvider(analysis.decompositionProvider());
+        System.out.println(TerminalFormatter.createBox("Structural Decomposition", decompositionContent, width));
+        System.out.println();
+        
+        // Examples section
+        String groupedExamples = TerminalFormatter.formatGroupedExamples(analysis.examples().usages());
+        String exampleContent = groupedExamples + "\n" + TerminalFormatter.formatProvider(analysis.exampleProvider());
+        System.out.println(TerminalFormatter.createBox("Examples", exampleContent, width));
+        System.out.println();
+        
+        // Explanation section with HTML conversion
+        String explanationContent = TerminalFormatter.convertHtmlToAnsi(analysis.explanation().explanation()) + "\n" +
+                                   TerminalFormatter.formatProvider(analysis.explanationProvider());
+        System.out.println(TerminalFormatter.createBox("Explanation", explanationContent, width));
+        
+        // Shutdown Jansi when done
+        Runtime.getRuntime().addShutdownHook(new Thread(TerminalFormatter::shutdown));
+    }
+    
+    private void printAnalysisRaw(WordAnalysis analysis, PlecoEntry originalEntry) {
+        System.out.println("Chinese Word: " + analysis.word().characters());
+        System.out.println("Original Pleco Pinyin: " + originalEntry.pinyin());
+        System.out.println("Original Pleco Definition: " + originalEntry.definitionText());
+        System.out.println("Default Provider: " + analysis.providerName());
+        System.out.println();
+        
+        System.out.println("Pinyin: " + analysis.pinyin().pinyin());
+        System.out.println("  Provider: " + analysis.pinyinProvider());
+        System.out.println();
+        
+        System.out.println("Definition: " + analysis.definition().meaning());
+        System.out.println("Part of Speech: " + analysis.definition().partOfSpeech());
+        System.out.println("  Provider: " + analysis.definitionProvider());
+        System.out.println();
+        
+        System.out.println("Structural Decomposition: " + analysis.structuralDecomposition().decomposition());
+        System.out.println("  Provider: " + analysis.decompositionProvider());
+        System.out.println();
+        
+        System.out.println("Examples:");
+        for (var usage : analysis.examples().usages()) {
+            System.out.println("  Chinese: " + usage.sentence());
+            System.out.println("  Pinyin: " + usage.pinyin());
+            System.out.println("  English: " + usage.translation());
+            if (usage.context() != null && !usage.context().isEmpty()) {
+                System.out.println("  Context: " + usage.context());
+            }
+        }
+        System.out.println("  Provider: " + analysis.exampleProvider());
+        System.out.println();
+        
+        System.out.println("Explanation: " + analysis.explanation().explanation());
+        System.out.println("  Provider: " + analysis.explanationProvider());
+    }
+}

--- a/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/dictionary/PlecoExportDictionary.java
+++ b/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/dictionary/PlecoExportDictionary.java
@@ -1,0 +1,100 @@
+package com.zhlearn.infrastructure.dictionary;
+
+import com.zhlearn.domain.dictionary.Dictionary;
+import com.zhlearn.domain.model.*;
+import com.zhlearn.infrastructure.pleco.PlecoEntry;
+import com.zhlearn.infrastructure.pleco.PlecoExportParser;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Dictionary implementation for Pleco export files.
+ * Provides lookup capability for words parsed from Pleco export data.
+ */
+public class PlecoExportDictionary implements Dictionary {
+    
+    private static final String DICTIONARY_NAME = "pleco-export";
+    private final Map<String, PlecoEntry> wordMap;
+    
+    /**
+     * Create a dictionary from a Pleco export file.
+     * 
+     * @param parser the parser to use for reading the file
+     * @param plecoFilePath path to the Pleco export file
+     * @throws IOException if the file cannot be read or parsed
+     */
+    public PlecoExportDictionary(PlecoExportParser parser, Path plecoFilePath) throws IOException {
+        this(parser.parseFile(plecoFilePath));
+    }
+    
+    /**
+     * Create a dictionary from a list of parsed PlecoEntry objects.
+     * 
+     * @param entries the list of PlecoEntry objects
+     */
+    public PlecoExportDictionary(List<PlecoEntry> entries) {
+        this.wordMap = entries.stream()
+            .filter(entry -> entry.hanzi() != null && !entry.hanzi().trim().isEmpty())
+            .collect(Collectors.toMap(
+                entry -> entry.hanzi().trim(),
+                Function.identity(),
+                (existing, replacement) -> existing // Keep first occurrence
+            ));
+    }
+    
+    @Override
+    public String getName() {
+        return DICTIONARY_NAME;
+    }
+    
+    @Override
+    public Optional<WordAnalysis> lookup(String simplifiedCharacters) {
+        if (simplifiedCharacters == null || simplifiedCharacters.trim().isEmpty()) {
+            return Optional.empty();
+        }
+        
+        PlecoEntry entry = wordMap.get(simplifiedCharacters.trim());
+        if (entry == null) {
+            return Optional.empty();
+        }
+        
+        return Optional.of(convertToWordAnalysis(entry));
+    }
+    
+    /**
+     * Convert a PlecoEntry to WordAnalysis using direct field mapping.
+     * No parsing of internal content - uses fields as-is.
+     * 
+     * @param entry the PlecoEntry to convert
+     * @return WordAnalysis object
+     */
+    private WordAnalysis convertToWordAnalysis(PlecoEntry entry) {
+        Hanzi hanzi = new Hanzi(entry.hanzi());
+        Pinyin pinyin = new Pinyin(entry.pinyin());
+        Definition definition = new Definition(entry.definitionText(), "unknown");
+        StructuralDecomposition decomposition = new StructuralDecomposition("unknown");
+        Example examples = new Example(List.of());
+        Explanation explanation = new Explanation(entry.definitionText());
+        
+        return new WordAnalysis(
+            hanzi,
+            pinyin,
+            definition,
+            decomposition,
+            examples,
+            explanation,
+            DICTIONARY_NAME,
+            DICTIONARY_NAME + "-pinyin",
+            DICTIONARY_NAME + "-definition",
+            DICTIONARY_NAME + "-decomposition", 
+            DICTIONARY_NAME + "-example",
+            DICTIONARY_NAME + "-explanation"
+        );
+    }
+}

--- a/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/pinyin/PinyinToneConverter.java
+++ b/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/pinyin/PinyinToneConverter.java
@@ -1,0 +1,137 @@
+package com.zhlearn.infrastructure.pinyin;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Utility to convert numbered pinyin (e.g., "shun4") to tone marks (e.g., "shùn").
+ *
+ * Rules implemented:
+ * - Identify syllables as letter blocks optionally ending with tone 1–5.
+ * - Neutral tone (5 or 0) removes the number without diacritics.
+ * - Vowel selection priority: a > e > ou (mark the 'o') > last vowel (covers iu/ui).
+ * - Treat 'u:' and 'v' as 'ü'.
+ * - Case-insensitive processing; output is lowercase (common for pinyin display).
+ */
+public class PinyinToneConverter {
+
+    // Match any pinyin syllable with a trailing tone number (1..5)
+    private static final Pattern SYLLABLE_WITH_TONE = Pattern.compile("(?i)([a-züv:]+)([1-5])");
+
+    private static final Map<Character, char[]> DIACRITIC_MAP = new HashMap<>();
+    static {
+        DIACRITIC_MAP.put('a', new char[]{'ā', 'á', 'ǎ', 'à'});
+        DIACRITIC_MAP.put('e', new char[]{'ē', 'é', 'ě', 'è'});
+        DIACRITIC_MAP.put('i', new char[]{'ī', 'í', 'ǐ', 'ì'});
+        DIACRITIC_MAP.put('o', new char[]{'ō', 'ó', 'ǒ', 'ò'});
+        DIACRITIC_MAP.put('u', new char[]{'ū', 'ú', 'ǔ', 'ù'});
+        DIACRITIC_MAP.put('ü', new char[]{'ǖ', 'ǘ', 'ǚ', 'ǜ'});
+    }
+
+    /**
+     * Convert numbered pinyin to tone marks. If no numbered syllables are found,
+     * returns the input trimmed.
+     */
+    public static String convertToToneMarks(String numberedPinyin) {
+        if (numberedPinyin == null || numberedPinyin.trim().isEmpty()) {
+            return numberedPinyin;
+        }
+
+        String input = numberedPinyin.trim();
+
+        Matcher m = SYLLABLE_WITH_TONE.matcher(input);
+        StringBuffer sb = new StringBuffer();
+        while (m.find()) {
+            String base = normalizeUmlaut(m.group(1).toLowerCase());
+            int tone = parseTone(m.group(2));
+            String replaced = applyTone(base, tone);
+            m.appendReplacement(sb, Matcher.quoteReplacement(replaced));
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+
+    private static int parseTone(String toneStr) {
+        try {
+            return Integer.parseInt(toneStr);
+        } catch (NumberFormatException e) {
+            return 5; // neutral
+        }
+    }
+
+    private static String normalizeUmlaut(String s) {
+        // Common numbered pinyin notations for ü
+        return s.replace("u:", "ü").replace('v', 'ü');
+    }
+
+    private static String applyTone(String base, int tone) {
+        if (tone <= 0 || tone == 5) {
+            // Neutral tone: return without number
+            return base;
+        }
+
+        int toneIdx = tone - 1; // 1..4 -> 0..3
+        int accentIndex = chooseAccentIndex(base);
+        if (accentIndex < 0) {
+            // No vowel, just return base
+            return base;
+        }
+
+        char ch = base.charAt(accentIndex);
+        char vowel = toPlainVowel(ch);
+        char[] diacritics = DIACRITIC_MAP.get(vowel);
+        if (diacritics == null) {
+            return base; // Shouldn't happen
+        }
+        char accented = diacritics[toneIdx];
+        StringBuilder sb = new StringBuilder(base);
+        sb.setCharAt(accentIndex, accented);
+        return sb.toString();
+    }
+
+    private static int chooseAccentIndex(String s) {
+        // Priority: a -> e -> ou(o) -> last vowel
+        int idxA = indexOfVowel(s, 'a');
+        if (idxA >= 0) return idxA;
+        int idxE = indexOfVowel(s, 'e');
+        if (idxE >= 0) return idxE;
+        int idxOu = indexOfSubstringIgnoreCase(s, "ou");
+        if (idxOu >= 0) return idxOu; // mark the 'o' in "ou"
+        // Fallback: last vowel among a e i o u ü
+        int last = -1;
+        for (int i = 0; i < s.length(); i++) {
+            char c = toPlainVowel(s.charAt(i));
+            if (DIACRITIC_MAP.containsKey(c)) {
+                last = i;
+            }
+        }
+        return last;
+    }
+
+    private static int indexOfVowel(String s, char vowel) {
+        for (int i = 0; i < s.length(); i++) {
+            if (toPlainVowel(s.charAt(i)) == vowel) return i;
+        }
+        return -1;
+    }
+
+    private static int indexOfSubstringIgnoreCase(String s, String sub) {
+        String lower = s.toLowerCase();
+        return lower.indexOf(sub.toLowerCase());
+    }
+
+    private static char toPlainVowel(char c) {
+        // Normalize any accented vowel back to plain for mapping decisions
+        return switch (c) {
+            case 'ā', 'á', 'ǎ', 'à', 'a' -> 'a';
+            case 'ē', 'é', 'ě', 'è', 'e' -> 'e';
+            case 'ī', 'í', 'ǐ', 'ì', 'i' -> 'i';
+            case 'ō', 'ó', 'ǒ', 'ò', 'o' -> 'o';
+            case 'ū', 'ú', 'ǔ', 'ù', 'u' -> 'u';
+            case 'ǖ', 'ǘ', 'ǚ', 'ǜ', 'ü' -> 'ü';
+            default -> c;
+        };
+    }
+}

--- a/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/pleco/PlecoEntry.java
+++ b/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/pleco/PlecoEntry.java
@@ -1,0 +1,37 @@
+package com.zhlearn.infrastructure.pleco;
+
+/**
+ * Represents a single entry from a Pleco export file.
+ * Each entry contains the Chinese characters, pinyin (converted to tone marks), 
+ * and definition text as-is from the export.
+ */
+public record PlecoEntry(
+    String hanzi,
+    String pinyin,
+    String definitionText
+) {
+    
+    /**
+     * Create a PlecoEntry with validation.
+     * 
+     * @param hanzi the Chinese characters
+     * @param pinyin the pinyin with tone marks
+     * @param definitionText the definition text (not parsed)
+     */
+    public PlecoEntry {
+        if (hanzi == null || hanzi.trim().isEmpty()) {
+            throw new IllegalArgumentException("hanzi cannot be null or empty");
+        }
+        if (pinyin == null || pinyin.trim().isEmpty()) {
+            throw new IllegalArgumentException("pinyin cannot be null or empty");  
+        }
+        if (definitionText == null) {
+            definitionText = "";
+        }
+        
+        // Trim all fields
+        hanzi = hanzi.trim();
+        pinyin = pinyin.trim();
+        definitionText = definitionText.trim();
+    }
+}

--- a/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/pleco/PlecoExportParser.java
+++ b/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/pleco/PlecoExportParser.java
@@ -1,0 +1,153 @@
+package com.zhlearn.infrastructure.pleco;
+
+import com.zhlearn.infrastructure.pinyin.PinyinToneConverter;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Parser for Pleco export files (TSV format).
+ * Parses entries with format: 序号→汉字	pinyin	definition_text
+ * Converts numbered pinyin to tone marks during parsing.
+ */
+public class PlecoExportParser {
+    
+    private static final CSVFormat TSV = CSVFormat.DEFAULT
+        .builder()
+        .setDelimiter('\t')
+        .setQuote('"')
+        .setIgnoreEmptyLines(false)
+        .setTrim(false)
+        .build();
+    
+    private static final Pattern SEQUENCE_PATTERN = Pattern.compile("^\\d+→(.*)$");
+    
+    /**
+     * Parse a Pleco export file from a file path.
+     * 
+     * @param file path to the Pleco export file
+     * @return list of parsed PlecoEntry objects
+     * @throws IOException if file cannot be read
+     */
+    public List<PlecoEntry> parseFile(Path file) throws IOException {
+        try (Reader r = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+            return parseFromReader(r);
+        }
+    }
+    
+    /**
+     * Parse Pleco export data from a Reader.
+     * 
+     * @param reader reader containing the TSV data
+     * @return list of parsed PlecoEntry objects  
+     * @throws IOException if data cannot be read
+     */
+    public List<PlecoEntry> parseFromReader(Reader reader) throws IOException {
+        List<PlecoEntry> entries = new ArrayList<>();
+        
+        try (CSVParser parser = TSV.parse(reader)) {
+            for (CSVRecord record : parser) {
+                if (record.size() == 0) continue;
+                
+                PlecoEntry entry = parseRecord(record);
+                if (entry != null) {
+                    entries.add(entry);
+                }
+            }
+        }
+        
+        return entries;
+    }
+    
+    /**
+     * Parse a single TSV record into a PlecoEntry.
+     * Expected format: 序号→汉字	pinyin	definition_text
+     * 
+     * @param record the CSV record to parse
+     * @return PlecoEntry or null if record is invalid
+     */
+    private PlecoEntry parseRecord(CSVRecord record) {
+        if (record.size() < 3) {
+            return null;
+        }
+        
+        String firstColumn = get(record, 0);
+        String pinyinColumn = get(record, 1);  
+        String definitionColumn = get(record, 2);
+        
+        // Extract hanzi from first column (remove sequence number prefix)
+        String hanzi = extractHanzi(firstColumn);
+        if (hanzi == null || hanzi.isEmpty()) {
+            return null;
+        }
+        
+        // Convert numbered pinyin to tone marks
+        String pinyin = PinyinToneConverter.convertToToneMarks(pinyinColumn);
+        if (pinyin == null || pinyin.isEmpty()) {
+            return null;
+        }
+        
+        // Definition text is used as-is
+        String definitionText = definitionColumn != null ? definitionColumn : "";
+        
+        try {
+            return new PlecoEntry(hanzi, pinyin, definitionText);
+        } catch (IllegalArgumentException e) {
+            // Skip invalid entries
+            return null;
+        }
+    }
+    
+    /**
+     * Extract hanzi characters from the first column by removing the sequence number prefix.
+     * For example: "1→瞬" -> "瞬"
+     * 
+     * @param firstColumn the first column value
+     * @return hanzi characters or null if invalid
+     */
+    private String extractHanzi(String firstColumn) {
+        if (firstColumn == null || firstColumn.trim().isEmpty()) {
+            return null;
+        }
+        
+        String trimmed = firstColumn.trim();
+        
+        // Handle BOM character if present
+        if (trimmed.startsWith("\uFEFF")) {
+            trimmed = trimmed.substring(1);
+        }
+        
+        // Try to match the pattern "序号→汉字"
+        var matcher = SEQUENCE_PATTERN.matcher(trimmed);
+        if (matcher.matches()) {
+            return matcher.group(1).trim();
+        }
+        
+        // If no sequence number pattern, return as-is (might be just hanzi)
+        return trimmed;
+    }
+    
+    /**
+     * Get a column value from a CSV record, handling null/empty cases.
+     * 
+     * @param record the CSV record
+     * @param index the column index
+     * @return column value or null if not available
+     */
+    private String get(CSVRecord record, int index) {
+        if (index >= record.size()) {
+            return null;
+        }
+        String value = record.get(index);
+        return value != null && !value.isEmpty() ? value : null;
+    }
+}

--- a/zh-learn-infrastructure/src/main/java/module-info.java
+++ b/zh-learn-infrastructure/src/main/java/module-info.java
@@ -31,6 +31,8 @@ module com.zhlearn.infrastructure {
     exports com.zhlearn.infrastructure.dictionary;
     exports com.zhlearn.infrastructure.cache;
     exports com.zhlearn.infrastructure.pinyin4j;
+    exports com.zhlearn.infrastructure.pinyin;
+    exports com.zhlearn.infrastructure.pleco;
     
     provides com.zhlearn.domain.provider.PinyinProvider
         with com.zhlearn.infrastructure.pinyin4j.Pinyin4jProvider;

--- a/zh-learn-infrastructure/src/test/java/com/zhlearn/infrastructure/dictionary/PlecoExportDictionaryTest.java
+++ b/zh-learn-infrastructure/src/test/java/com/zhlearn/infrastructure/dictionary/PlecoExportDictionaryTest.java
@@ -1,0 +1,35 @@
+package com.zhlearn.infrastructure.dictionary;
+
+import com.zhlearn.domain.model.WordAnalysis;
+import com.zhlearn.infrastructure.pleco.PlecoEntry;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PlecoExportDictionaryTest {
+
+    @Test
+    void lookupReturnsAnalysisFromEntries() {
+        PlecoEntry entry = new PlecoEntry("瞬", "shùn", "verb wink; twinkle");
+        PlecoExportDictionary dict = new PlecoExportDictionary(List.of(entry));
+
+        assertEquals("pleco-export", dict.getName());
+        Optional<WordAnalysis> maybe = dict.lookup("瞬");
+        assertTrue(maybe.isPresent());
+        WordAnalysis wa = maybe.get();
+        assertEquals("瞬", wa.word().characters());
+        assertEquals("shùn", wa.pinyin().pinyin());
+        assertEquals("verb wink; twinkle", wa.definition().meaning());
+        assertEquals("pleco-export", wa.providerName());
+    }
+
+    @Test
+    void lookupIsEmptyWhenNotPresent() {
+        PlecoExportDictionary dict = new PlecoExportDictionary(List.of());
+        assertTrue(dict.lookup("不存在").isEmpty());
+    }
+}
+

--- a/zh-learn-infrastructure/src/test/java/com/zhlearn/infrastructure/pinyin/PinyinToneConverterTest.java
+++ b/zh-learn-infrastructure/src/test/java/com/zhlearn/infrastructure/pinyin/PinyinToneConverterTest.java
@@ -1,0 +1,40 @@
+package com.zhlearn.infrastructure.pinyin;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PinyinToneConverterTest {
+
+    @Test
+    void convertsSingleSyllable() {
+        assertEquals("shùn", PinyinToneConverter.convertToToneMarks("shun4"));
+        assertEquals("mà", PinyinToneConverter.convertToToneMarks("ma4"));
+    }
+
+    @Test
+    void convertsMultiSyllable() {
+        assertEquals("zhōng guó", PinyinToneConverter.convertToToneMarks("zhong1 guo2"));
+        assertEquals("hǎo péngyǒu", PinyinToneConverter.convertToToneMarks("hao3 peng2you3"));
+    }
+
+    @Test
+    void appliesOuRuleAndIuUiRules() {
+        assertEquals("ǒu", PinyinToneConverter.convertToToneMarks("ou3"));
+        assertEquals("shuǐ", PinyinToneConverter.convertToToneMarks("shui3"));
+        assertEquals("liú", PinyinToneConverter.convertToToneMarks("liu2"));
+    }
+
+    @Test
+    void handlesUmlautVariants() {
+        assertEquals("lüè", PinyinToneConverter.convertToToneMarks("lu:e4"));
+        assertEquals("lüè", PinyinToneConverter.convertToToneMarks("lve4"));
+        assertEquals("lǜ", PinyinToneConverter.convertToToneMarks("lv4"));
+    }
+
+    @Test
+    void neutralToneDropsNumber() {
+        assertEquals("r", PinyinToneConverter.convertToToneMarks("r5"));
+    }
+}
+

--- a/zh-learn-infrastructure/src/test/java/com/zhlearn/infrastructure/pleco/PlecoExportParserTest.java
+++ b/zh-learn-infrastructure/src/test/java/com/zhlearn/infrastructure/pleco/PlecoExportParserTest.java
@@ -1,0 +1,57 @@
+package com.zhlearn.infrastructure.pleco;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PlecoExportParserTest {
+
+    @Test
+    void parsesBasicTsvWithSequenceArrow() throws Exception {
+        String data = "1→瞬\tshun4\tverb wink; twinkle\n" +
+                      "2→胸\txiong1\tnoun chest\n";
+        PlecoExportParser parser = new PlecoExportParser();
+        List<PlecoEntry> entries = parser.parseFromReader(new StringReader(data));
+
+        assertEquals(2, entries.size());
+        PlecoEntry e1 = entries.get(0);
+        assertEquals("瞬", e1.hanzi());
+        assertEquals("shùn", e1.pinyin());
+        assertEquals("verb wink; twinkle", e1.definitionText());
+
+        PlecoEntry e2 = entries.get(1);
+        assertEquals("胸", e2.hanzi());
+        assertEquals("xiōng", e2.pinyin());
+        assertEquals("noun chest", e2.definitionText());
+    }
+
+    @Test
+    void handlesBomInFirstColumn() throws Exception {
+        String data = "\uFEFF3→然\tran2\tverb burn\n";
+        PlecoExportParser parser = new PlecoExportParser();
+        List<PlecoEntry> entries = parser.parseFromReader(new StringReader(data));
+
+        assertEquals(1, entries.size());
+        PlecoEntry e = entries.get(0);
+        assertEquals("然", e.hanzi());
+        assertEquals("rán", e.pinyin());
+        assertEquals("verb burn", e.definitionText());
+    }
+
+    @Test
+    void skipsInvalidRows() throws Exception {
+        String data = "not-enough-cols\n" +
+                      "4→\t\t\n" +
+                      "5→冗\t\tdefinition only\n" +
+                      "6→燃\tran2\tverb burn\n";
+        PlecoExportParser parser = new PlecoExportParser();
+        List<PlecoEntry> entries = parser.parseFromReader(new StringReader(data));
+
+        assertEquals(1, entries.size());
+        assertEquals("燃", entries.get(0).hanzi());
+    }
+}
+


### PR DESCRIPTION
This PR adds Pleco TSV parsing and integrates dictionary-backed providers, plus a robust pinyin converter and tests.\n\nWhat's included:\n- New CLI command: `parse-pleco` to parse Pleco exports (TSV), register dictionary-backed providers (definition/explanation/decomposition), and run the standard analysis pipeline per word.\n- Infrastructure: `PlecoExportParser`, `PlecoEntry`, and `PlecoExportDictionary`.\n- Pinyin: redesigned `PinyinToneConverter` with syllable-aware tone placement (a > e > ou > last-vowel), proper ü handling (u:, v), and neutral tone behavior.\n- Tests: inline-data unit tests for converter, parser, and dictionary.\n- Module: export new packages `com.zhlearn.infrastructure.pinyin` and `com.zhlearn.infrastructure.pleco`.\n- Repo: ignore `flash.txt` (sample data) via .gitignore.\n\nBuild & test:\n- `mvn clean package`\n- `mvn test` (all tests pass locally)\n\nCLI example:\n- `./zh-learn.sh parse-pleco flash.txt --limit 2 --definition-provider dictionary-definition-pleco-export --explanation-provider dictionary-explanation-pleco-export --decomposition-provider dictionary-decomposition-pleco-export`\n\nNotes:\n- By default, pinyin uses `pinyin4j`. You can override providers via flags.\n- Dictionary-backed providers expose Pleco content to the pipeline; examples remain from dummy/AI providers as configured.