### PR TITLE
refactor: remove provider metadata from word analysis

### DIFF
--- a/zh-learn-application/src/main/java/com/zhlearn/application/service/ParallelWordAnalysisService.java
+++ b/zh-learn-application/src/main/java/com/zhlearn/application/service/ParallelWordAnalysisService.java
@@ -131,14 +131,7 @@ public class ParallelWordAnalysisService implements WordAnalysisService {
                 decompositionFuture.get(),
                 examplesFuture.get(),
                 explanationFuture.get(),
-                pronunciationFuture.get(),
-                config.getDefaultProvider(),
-                config.getPinyinProvider(),
-                config.getDefinitionProvider(),
-                config.getDecompositionProvider(),
-                config.getExampleProvider(),
-                config.getExplanationProvider(),
-                config.getAudioProvider()
+                pronunciationFuture.get()
             );
         } catch (Exception e) {
             throw new RuntimeException("Error in parallel word analysis: " + e.getMessage(), e);

--- a/zh-learn-application/src/main/java/com/zhlearn/application/service/WordAnalysisServiceImpl.java
+++ b/zh-learn-application/src/main/java/com/zhlearn/application/service/WordAnalysisServiceImpl.java
@@ -77,17 +77,10 @@ public class WordAnalysisServiceImpl implements WordAnalysisService {
             getStructuralDecomposition(word, providerName),
             getExamples(word, providerName, definition.meaning()),
             getExplanation(word, providerName),
-            getPronunciation(word, pinyin, providerName),
-            providerName,
-            providerName, // pinyinProvider
-            providerName, // definitionProvider
-            providerName, // decompositionProvider
-            providerName, // exampleProvider
-            providerName, // explanationProvider
-            providerName  // audioProvider
+            getPronunciation(word, pinyin, providerName)
         );
     }
-    
+
     @Override
     public WordAnalysis getCompleteAnalysis(Hanzi word, ProviderConfiguration config) {
         Definition definition = getDefinition(word, config.getDefinitionProvider());
@@ -99,14 +92,7 @@ public class WordAnalysisServiceImpl implements WordAnalysisService {
             getStructuralDecomposition(word, config.getDecompositionProvider()),
             getExamples(word, config.getExampleProvider(), definition.meaning()),
             getExplanation(word, config.getExplanationProvider()),
-            getPronunciation(word, pinyin, config.getAudioProvider()),
-            config.getDefaultProvider(),
-            config.getPinyinProvider(),
-            config.getDefinitionProvider(),
-            config.getDecompositionProvider(),
-            config.getExampleProvider(),
-            config.getExplanationProvider(),
-            config.getAudioProvider()
+            getPronunciation(word, pinyin, config.getAudioProvider())
         );
     }
 

--- a/zh-learn-cli/src/main/java/com/zhlearn/cli/AnalysisPrinter.java
+++ b/zh-learn-cli/src/main/java/com/zhlearn/cli/AnalysisPrinter.java
@@ -14,37 +14,31 @@ public final class AnalysisPrinter {
         int width = TerminalFormatter.getTerminalWidth();
 
         String wordContent = TerminalFormatter.formatChineseWord(
-                analysis.word().characters(), analysis.pinyin().pinyin()) + "\n" +
-                TerminalFormatter.formatProvider("Default: " + analysis.providerName());
+                analysis.word().characters(), analysis.pinyin().pinyin());
         System.out.println(TerminalFormatter.createBox("Chinese Word", wordContent, width));
         System.out.println();
 
-        String pinyinContent = TerminalFormatter.formatChineseWord("拼音", analysis.pinyin().pinyin()) + "\n" +
-                TerminalFormatter.formatProvider(analysis.pinyinProvider());
+        String pinyinContent = TerminalFormatter.formatChineseWord("拼音", analysis.pinyin().pinyin());
         System.out.println(TerminalFormatter.createBox("Pinyin", pinyinContent, width));
         System.out.println();
 
         String defContent = TerminalFormatter.formatDefinition(
-                analysis.definition().meaning()) + "\n" +
-                TerminalFormatter.formatProvider(analysis.definitionProvider());
+                analysis.definition().meaning());
         System.out.println(TerminalFormatter.createBox("Definition", defContent, width));
         System.out.println();
 
         String decompositionContent = TerminalFormatter.formatStructuralDecomposition(
-                analysis.structuralDecomposition().decomposition()) + "\n" +
-                TerminalFormatter.formatProvider(analysis.decompositionProvider());
+                analysis.structuralDecomposition().decomposition());
         System.out.println(TerminalFormatter.createBox("Structural Decomposition", decompositionContent, width));
         System.out.println();
 
         String examplesHtml = ExamplesHtmlFormatter.format(analysis.examples());
         String formattedExamples = TerminalFormatter.convertHtmlToAnsi(examplesHtml);
-        String exampleContent = formattedExamples + "\n" + TerminalFormatter.formatProvider(analysis.exampleProvider());
-        System.out.println(TerminalFormatter.createBox("Examples", exampleContent, width));
+        System.out.println(TerminalFormatter.createBox("Examples", formattedExamples, width));
         System.out.println();
 
         String explanationContent = TerminalFormatter.convertHtmlToAnsi(
-                analysis.explanation().explanation()) + "\n" +
-                TerminalFormatter.formatProvider(analysis.explanationProvider());
+                analysis.explanation().explanation());
         System.out.println(TerminalFormatter.createBox("Explanation", explanationContent, width));
 
         Runtime.getRuntime().addShutdownHook(new Thread(TerminalFormatter::shutdown));
@@ -52,19 +46,15 @@ public final class AnalysisPrinter {
 
     public static void printRaw(WordAnalysis analysis) {
         System.out.println("Chinese Word: " + analysis.word().characters());
-        System.out.println("Default Provider: " + analysis.providerName());
         System.out.println();
 
         System.out.println("Pinyin: " + analysis.pinyin().pinyin());
-        System.out.println("  Provider: " + analysis.pinyinProvider());
         System.out.println();
 
         System.out.println("Definition: " + analysis.definition().meaning());
-        System.out.println("  Provider: " + analysis.definitionProvider());
         System.out.println();
 
         System.out.println("Structural Decomposition: " + analysis.structuralDecomposition().decomposition());
-        System.out.println("  Provider: " + analysis.decompositionProvider());
         System.out.println();
 
         System.out.println("Examples:");
@@ -85,10 +75,8 @@ public final class AnalysisPrinter {
                 System.out.println("    • " + item.hanzi() + pinyin + meaning);
             }
         }
-        System.out.println("  Provider: " + analysis.exampleProvider());
         System.out.println();
 
         System.out.println("Explanation: " + analysis.explanation().explanation());
-        System.out.println("  Provider: " + analysis.explanationProvider());
     }
 }

--- a/zh-learn-cli/src/test/java/com/zhlearn/cli/WordAnalysisStepDefinitions.java
+++ b/zh-learn-cli/src/test/java/com/zhlearn/cli/WordAnalysisStepDefinitions.java
@@ -154,16 +154,13 @@ public class WordAnalysisStepDefinitions {
         var rows = dataTable.asLists(String.class);
         for (var row : rows) {
             if (row.size() != 2) continue;
-            
+
             String field = row.get(0);
             String expectedValue = row.get(1);
-            
+
             switch (field) {
                 case "word":
                     assertEquals(expectedValue, currentAnalysis.word().characters());
-                    break;
-                case "provider_name":
-                    assertEquals(expectedValue, currentAnalysis.providerName());
                     break;
                 case "pinyin_available":
                     assertEquals(Boolean.parseBoolean(expectedValue), currentAnalysis.pinyin() != null);
@@ -188,12 +185,6 @@ public class WordAnalysisStepDefinitions {
     public void the_analysis_should_be_successful() {
         assertNull(lastException);
         assertNotNull(currentAnalysis);
-    }
-    
-    @Then("the provider name should be {string}")
-    public void the_provider_name_should_be(String expectedProvider) {
-        assertNotNull(currentAnalysis);
-        assertEquals(expectedProvider, currentAnalysis.providerName());
     }
     
     @Then("the pinyin should be {string}")

--- a/zh-learn-cli/src/test/resources/features/word_analysis.feature
+++ b/zh-learn-cli/src/test/resources/features/word_analysis.feature
@@ -7,7 +7,6 @@ Feature: Chinese Word Analysis
     Given the ZH Learn application is available
     When I analyze the word "你好" using provider "dummy"
     Then the analysis should be successful
-    And the provider name should be "dummy"
 #    And the pinyin should be "dummy-pinyin-你好"
 #    And the definition meaning should be "Dummy meaning for 你好"
 #    And the structural decomposition should be "Dummy structural decomposition for 你好: Component breakdown with radicals and meanings."

--- a/zh-learn-domain/src/main/java/com/zhlearn/domain/model/WordAnalysis.java
+++ b/zh-learn-domain/src/main/java/com/zhlearn/domain/model/WordAnalysis.java
@@ -9,14 +9,7 @@ public record WordAnalysis(
     StructuralDecomposition structuralDecomposition,
     Example examples,
     Explanation explanation,
-    Optional<String> pronunciation,
-    String providerName,
-    String pinyinProvider,
-    String definitionProvider,
-    String decompositionProvider,
-    String exampleProvider,
-    String explanationProvider,
-    String audioProvider
+    Optional<String> pronunciation
 ) {
     public WordAnalysis {
         if (word == null) {
@@ -39,27 +32,6 @@ public record WordAnalysis(
         }
         if (pronunciation == null) {
             throw new IllegalArgumentException("Pronunciation cannot be null");
-        }
-        if (providerName == null || providerName.trim().isEmpty()) {
-            throw new IllegalArgumentException("Provider name cannot be null or empty");
-        }
-        if (pinyinProvider == null || pinyinProvider.trim().isEmpty()) {
-            throw new IllegalArgumentException("Pinyin provider cannot be null or empty");
-        }
-        if (definitionProvider == null || definitionProvider.trim().isEmpty()) {
-            throw new IllegalArgumentException("Definition provider cannot be null or empty");
-        }
-        if (decompositionProvider == null || decompositionProvider.trim().isEmpty()) {
-            throw new IllegalArgumentException("Decomposition provider cannot be null or empty");
-        }
-        if (exampleProvider == null || exampleProvider.trim().isEmpty()) {
-            throw new IllegalArgumentException("Example provider cannot be null or empty");
-        }
-        if (explanationProvider == null || explanationProvider.trim().isEmpty()) {
-            throw new IllegalArgumentException("Explanation provider cannot be null or empty");
-        }
-        if (audioProvider == null || audioProvider.trim().isEmpty()) {
-            throw new IllegalArgumentException("Audio provider cannot be null or empty");
         }
     }
 }

--- a/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/dictionary/AnkiCardDictionary.java
+++ b/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/dictionary/AnkiCardDictionary.java
@@ -70,14 +70,7 @@ public class AnkiCardDictionary implements Dictionary {
             decomposition,
             examples,
             explanation,
-            java.util.Optional.empty(), // no pronunciation available from dictionary
-            DICTIONARY_NAME,
-            DICTIONARY_NAME + "-pinyin",
-            DICTIONARY_NAME + "-definition",
-            DICTIONARY_NAME + "-decomposition",
-            DICTIONARY_NAME + "-example",
-            DICTIONARY_NAME + "-explanation",
-            DICTIONARY_NAME + "-audio" // placeholder audio provider
+            java.util.Optional.empty() // no pronunciation available from dictionary
         );
     }
 

--- a/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/dictionary/AnkiNoteDictionary.java
+++ b/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/dictionary/AnkiNoteDictionary.java
@@ -60,14 +60,7 @@ public class AnkiNoteDictionary implements Dictionary {
             decomposition,
             examples,
             explanation,
-            java.util.Optional.empty(), // no pronunciation available from dictionary
-            DICTIONARY_NAME,
-            DICTIONARY_NAME + "-pinyin",
-            DICTIONARY_NAME + "-definition",
-            DICTIONARY_NAME + "-decomposition",
-            DICTIONARY_NAME + "-example",
-            DICTIONARY_NAME + "-explanation",
-            DICTIONARY_NAME + "-audio" // placeholder audio provider
+            java.util.Optional.empty() // no pronunciation available from dictionary
         );
     }
 

--- a/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/dictionary/PlecoExportDictionary.java
+++ b/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/dictionary/PlecoExportDictionary.java
@@ -81,7 +81,7 @@ public class PlecoExportDictionary implements Dictionary {
         StructuralDecomposition decomposition = new StructuralDecomposition("unknown");
         Example examples = new Example(List.of(), List.of());
         Explanation explanation = new Explanation(entry.definitionText());
-        
+
         return new WordAnalysis(
             hanzi,
             pinyin,
@@ -89,14 +89,7 @@ public class PlecoExportDictionary implements Dictionary {
             decomposition,
             examples,
             explanation,
-            java.util.Optional.empty(), // no pronunciation available from dictionary
-            DICTIONARY_NAME,
-            DICTIONARY_NAME,
-            DICTIONARY_NAME,
-            DICTIONARY_NAME,
-            DICTIONARY_NAME,
-            DICTIONARY_NAME,
-            DICTIONARY_NAME
+            java.util.Optional.empty() // no pronunciation available from dictionary
         );
     }
 }

--- a/zh-learn-infrastructure/src/test/java/com/zhlearn/infrastructure/dictionary/PlecoExportDictionaryTest.java
+++ b/zh-learn-infrastructure/src/test/java/com/zhlearn/infrastructure/dictionary/PlecoExportDictionaryTest.java
@@ -23,7 +23,6 @@ class PlecoExportDictionaryTest {
         assertEquals("瞬", wa.word().characters());
         assertEquals("shùn", wa.pinyin().pinyin());
         assertEquals("verb wink; twinkle", wa.definition().meaning());
-        assertEquals("pleco-export", wa.providerName());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- drop provider fields from `WordAnalysis` and related validation
- build word analyses without provider metadata in services and dictionaries
- simplify CLI output and tests to ignore provider names

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c47cf3f348832ab6a27b0e3c7eb112