### PR TITLE
feat: store llm cache under home directory

### DIFF
--- a/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/cache/FileSystemCache.java
+++ b/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/cache/FileSystemCache.java
@@ -6,7 +6,6 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.Optional;
 
@@ -18,7 +17,15 @@ public class FileSystemCache {
     private final long ttlSeconds;
     
     public FileSystemCache() {
-        this(Paths.get(".zh-learn-cache"), DEFAULT_TTL_SECONDS);
+        this(resolveDefaultCacheDirectory(), DEFAULT_TTL_SECONDS);
+    }
+
+    private static Path resolveDefaultCacheDirectory() {
+        String userHome = System.getProperty("user.home");
+        if (userHome == null || userHome.isBlank()) {
+            throw new IllegalStateException("user.home system property must be set to resolve the cache directory");
+        }
+        return Path.of(userHome, ".zh-learn", "cache");
     }
     
     public FileSystemCache(Path cacheDirectory, long ttlSeconds) {

--- a/zh-learn-infrastructure/src/test/java/com/zhlearn/infrastructure/cache/FileSystemCacheTest.java
+++ b/zh-learn-infrastructure/src/test/java/com/zhlearn/infrastructure/cache/FileSystemCacheTest.java
@@ -2,10 +2,12 @@ package com.zhlearn.infrastructure.cache;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
 import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class FileSystemCacheTest {
 
@@ -64,14 +66,57 @@ class FileSystemCacheTest {
     void shouldCreateCacheDirectoryStructure() {
         FileSystemCache cache = new FileSystemCache(tempDir, 3600);
         String key = "abcdef1234567890";
-        
+
         cache.put(key, "test");
-        
+
         // Verify directory structure is created
         Path expectedDir = tempDir.resolve("responses").resolve("ab");
         assertThat(expectedDir).exists();
-        
+
         Path expectedFile = expectedDir.resolve(key + ".cache");
         assertThat(expectedFile).exists();
+    }
+
+    @Test
+    void defaultConstructorThrowsWhenUserHomeMissing() {
+        String originalUserHome = System.getProperty("user.home");
+        try {
+            System.clearProperty("user.home");
+
+            assertThatThrownBy(FileSystemCache::new)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("user.home system property must be set");
+        } finally {
+            if (originalUserHome == null) {
+                System.clearProperty("user.home");
+            } else {
+                System.setProperty("user.home", originalUserHome);
+            }
+        }
+    }
+
+    @Test
+    void defaultConstructorCreatesCacheUnderZhLearnDirectory(@TempDir Path tempHome) throws Exception {
+        String originalUserHome = System.getProperty("user.home");
+        try {
+            System.setProperty("user.home", tempHome.toString());
+
+            FileSystemCache cache = new FileSystemCache();
+
+            Path expectedCacheDir = tempHome.resolve(".zh-learn").resolve("cache");
+            Path expectedResponsesDir = expectedCacheDir.resolve("responses");
+            assertThat(expectedResponsesDir).exists();
+
+            var cacheDirectoryField = FileSystemCache.class.getDeclaredField("cacheDirectory");
+            cacheDirectoryField.setAccessible(true);
+            Path actualCacheDir = (Path) cacheDirectoryField.get(cache);
+            assertThat(actualCacheDir).isEqualTo(expectedCacheDir);
+        } finally {
+            if (originalUserHome == null) {
+                System.clearProperty("user.home");
+            } else {
+                System.setProperty("user.home", originalUserHome);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- default the LLM file-system cache to the ~/.zh-learn/cache directory and require the `user.home` system property instead of falling back to the working directory
- add unit coverage for the thrown exception when `user.home` is missing alongside the default path assertion when it is set

## Testing
- `mvn -pl zh-learn-infrastructure test` *(fails: unable to reach https://repo.maven.apache.org to resolve dependencies)*

## Constitution Check
- ✅ I have read and followed the Constitution in `.specify/memory/constitution.md` for this change.


------
https://chatgpt.com/codex/tasks/task_e_68cc5875d264832ab1e11328c88837d1