### PR TITLE
feat: improve definition formatter prompts to prevent content generation and ensure abbreviation expansion

### DIFF
--- a/DEFINITION_FORMATTER_PLAN.md
+++ b/DEFINITION_FORMATTER_PLAN.md
@@ -1,0 +1,484 @@
+# Definition Formatter Provider Implementation Plan
+
+## Overview
+
+This plan outlines the implementation of a new AI provider type: **DefinitionFormatterProvider**. This provider follows the same pattern as `ExampleProvider`, `ExplanationProvider`, etc., and can be backed by any AI service (deepseek-chat, glm-4.5, etc.) to format or generate HTML-formatted definitions for Chinese words.
+
+## Background
+
+### Current State
+- **AI Provider Pattern**: Providers like `ExampleProvider`, `ExplanationProvider` follow a consistent pattern with `ConfigurableXXXProvider` implementations backed by any AI service
+- **AIProviderFactory**: Creates providers with separate single-char and multi-char configurations
+- **Resource Structure**: Prompt templates stored in `zh-learn-infrastructure/src/main/resources/{single-char,multi-char}/{provider-type}/prompt-template.md`
+- **Parse-pleco command**: Uses various providers through the factory pattern
+- **Existing DefinitionProvider**: For *looking up* definitions from data sources (different from formatting)
+
+### Requirements
+1. **New AI provider type**: `DefinitionFormatterProvider` that formats/generates definitions using AI
+2. **Input**: Chinese word + Optional raw definition (from Pleco or other sources)
+3. **AI-powered processing**: Both single-char and multi-char words processed through AI with different prompts
+4. **Parse-pleco integration**: Pass Pleco definition when available for AI formatting/enhancement
+5. **Provider selection**: Support all AI backends (deepseek-chat, glm-4-flash, glm-4.5, etc.)
+6. **Prompt usage**:
+   - Single-char: `single-char/definition/prompt-template.md` - minimal formatting of existing definition
+   - Multi-char: `multi-char/definition/prompt-template.md` - complex formatting or generation
+
+## Design Architecture
+
+### 1. Domain Layer (`zh-learn-domain`)
+
+#### New Interface: `DefinitionFormatterProvider`
+```java
+package com.zhlearn.domain.provider;
+
+import com.zhlearn.domain.model.Hanzi;
+import com.zhlearn.domain.model.Definition;
+import com.zhlearn.domain.model.ProviderInfo.ProviderType;
+import java.util.Optional;
+
+public interface DefinitionFormatterProvider {
+    String getName();
+    String getDescription();
+    ProviderType getType();
+
+    /**
+     * Format or generate a definition for the given Chinese word using AI.
+     *
+     * @param word The Chinese word to format a definition for
+     * @param rawDefinition Optional raw definition (typically from Pleco export).
+     *                     If present, AI will format it. If empty, AI may generate new definition.
+     * @return AI-formatted HTML definition, or null if cannot process
+     */
+    Definition formatDefinition(Hanzi word, Optional<String> rawDefinition);
+}
+```
+
+**Key Points**:
+- Follows same interface pattern as `ExampleProvider`
+- Takes `Optional<String>` raw definition (like `ExampleProvider` takes optional definition)
+- Always returns AI-processed content (even for single characters)
+
+### 2. Infrastructure Layer (`zh-learn-infrastructure`)
+
+#### New Implementation: `ConfigurableDefinitionFormatterProvider`
+```java
+package com.zhlearn.infrastructure.common;
+
+public class ConfigurableDefinitionFormatterProvider implements DefinitionFormatterProvider {
+    private final BiFunction<Hanzi, Optional<String>, Definition> singleCharProcessor;
+    private final BiFunction<Hanzi, Optional<String>, Definition> multiCharProcessor;
+    // ... similar structure to ConfigurableExampleProvider
+
+    @Override
+    public Definition formatDefinition(Hanzi word, Optional<String> rawDefinition) {
+        WordType type = WordType.from(word);
+        return selectProcessor(type).apply(word, rawDefinition);
+    }
+}
+```
+
+This follows the exact same pattern as `ConfigurableExampleProvider`:
+- **Single-char processor**: Uses AI with simple formatting prompt
+- **Multi-char processor**: Uses AI with complex formatting/generation prompt
+- **Constructor variants**: Support different AI backends and configurations
+
+#### New Configuration Classes
+
+**Single-Char Configuration**:
+```java
+package com.zhlearn.infrastructure.common;
+
+public class SingleCharDefinitionFormatterProviderConfig {
+    public static String templatePath() {
+        return "single-char/definition/prompt-template.md";
+    }
+
+    public static String examplesDirectory() {
+        return "single-char/definition/examples";
+    }
+
+    public static Function<String, Definition> responseMapper() {
+        return response -> new Definition(response.trim());
+    }
+}
+```
+
+**Multi-Char Configuration**:
+```java
+package com.zhlearn.infrastructure.common;
+
+public class MultiCharDefinitionFormatterProviderConfig {
+    public static String templatePath() {
+        return "multi-char/definition/prompt-template.md";
+    }
+
+    public static String examplesDirectory() {
+        return "multi-char/definition/examples";
+    }
+
+    public static Function<String, Definition> responseMapper() {
+        return response -> new Definition(response.trim());
+    }
+}
+```
+
+#### Updates to AIProviderFactory
+Add new method following the exact same pattern as `createExampleProvider`:
+
+```java
+public static DefinitionFormatterProvider createDefinitionFormatterProvider(String providerName) {
+    if (providerName == null) providerName = "deepseek-chat";
+
+    return switch (providerName) {
+        case "dummy" -> new DummyDefinitionFormatterProvider();
+        case "deepseek-chat" -> {
+            requireAPIKey("DEEPSEEK_API_KEY", providerName);
+            ProviderConfig<Definition> singleConfig = createProviderConfig(
+                DeepSeekConfig.getApiKey(),
+                DeepSeekConfig.getBaseUrl(),
+                "deepseek-chat",
+                SingleCharDefinitionFormatterProviderConfig.templatePath(),
+                SingleCharDefinitionFormatterProviderConfig.examplesDirectory(),
+                SingleCharDefinitionFormatterProviderConfig.responseMapper(),
+                providerName,
+                "Failed to format definition from DeepSeek (deepseek-chat)"
+            );
+            ProviderConfig<Definition> multiConfig = createProviderConfig(
+                DeepSeekConfig.getApiKey(),
+                DeepSeekConfig.getBaseUrl(),
+                "deepseek-chat",
+                MultiCharDefinitionFormatterProviderConfig.templatePath(),
+                MultiCharDefinitionFormatterProviderConfig.examplesDirectory(),
+                MultiCharDefinitionFormatterProviderConfig.responseMapper(),
+                providerName,
+                "Failed to format definition from DeepSeek (deepseek-chat)"
+            );
+            yield new ConfigurableDefinitionFormatterProvider(singleConfig, multiConfig, providerName, "DeepSeek AI-powered definition formatter");
+        }
+        case "glm-4-flash" -> {
+            requireAPIKey("ZHIPU_API_KEY", providerName);
+            // Similar pattern with ZhipuChatModelProvider delegate...
+        }
+        case "glm-4.5" -> {
+            // Similar pattern...
+        }
+        case "qwen-max", "qwen-plus", "qwen-turbo" -> {
+            // Similar pattern...
+        }
+        // ... all other AI providers
+        default -> throw new IllegalArgumentException("Unknown definition formatter provider: " + providerName);
+    };
+}
+```
+
+#### Dummy Implementation
+```java
+package com.zhlearn.infrastructure.dummy;
+
+public class DummyDefinitionFormatterProvider implements DefinitionFormatterProvider {
+    @Override
+    public Definition formatDefinition(Hanzi word, Optional<String> rawDefinition) {
+        String formatted = rawDefinition.orElse("dummy definition for " + word.characters());
+        return new Definition("<span class=\"part-of-speech\">dummy</span> " + formatted);
+    }
+    // ... other methods
+}
+```
+
+### 3. Application Layer (`zh-learn-application`)
+
+#### Service Integration
+Update `WordAnalysisServiceImpl` to optionally use definition formatting:
+
+```java
+public class WordAnalysisServiceImpl implements WordAnalysisService {
+    private final DefinitionFormatterProvider definitionFormatterProvider; // Optional
+
+    public WordAnalysis getCompleteAnalysis(Hanzi word, ProviderConfiguration config) {
+        // Get raw definition from DefinitionProvider
+        Definition rawDefinition = definitionProvider.getDefinition(word);
+
+        // Format definition if formatter is available
+        Definition finalDefinition = rawDefinition;
+        if (definitionFormatterProvider != null) {
+            Optional<String> rawText = rawDefinition != null
+                ? Optional.of(rawDefinition.meaning())
+                : Optional.empty();
+            Definition formatted = definitionFormatterProvider.formatDefinition(word, rawText);
+            if (formatted != null) {
+                finalDefinition = formatted;
+            }
+        }
+
+        // Use finalDefinition in WordAnalysis...
+    }
+}
+```
+
+#### Configuration Updates
+Add `DefinitionFormatterProvider` to `ProviderConfiguration`:
+
+```java
+public record ProviderConfiguration(
+    String exampleProvider,
+    String pinyinProvider,
+    String definitionProvider,
+    String definitionFormatterProvider, // NEW
+    String decompositionProvider,
+    String explanationProvider,
+    String audioProvider
+) {}
+```
+
+### 4. CLI Layer (`zh-learn-cli`)
+
+#### Updates to MainCommand
+Add definition formatter provider support following existing pattern:
+
+```java
+public class MainCommand {
+    // Add to createProviders() method:
+    public DefinitionFormatterProvider createDefinitionFormatterProvider(String providerName) {
+        return AIProviderFactory.createDefinitionFormatterProvider(providerName);
+    }
+}
+```
+
+#### Updates to ParsePlecoCommand
+Add new command line option:
+
+```java
+@Option(names = {"--definition-formatter-provider"},
+        description = "Set specific provider for definition formatting (default: deepseek-chat). Available: dummy, deepseek-chat, glm-4-flash, glm-4.5, qwen-max, qwen-plus, qwen-turbo",
+        defaultValue = "deepseek-chat")
+private String definitionFormatterProvider;
+```
+
+Update provider configuration and service creation:
+
+```java
+// In run() method:
+DefinitionFormatterProvider defFormatterProv = parent.createDefinitionFormatterProvider(definitionFormatterProvider);
+
+WordAnalysisServiceImpl baseService = new WordAnalysisServiceImpl(
+    exampleProv, explanationProv, decompositionProv, pinyinProv, definitionProv, defFormatterProv, audioProv
+);
+
+ProviderConfiguration config = new ProviderConfiguration(
+    exampleProvider,
+    pinyinProvider,
+    definitionProvider,
+    definitionFormatterProvider, // NEW
+    decompositionProvider,
+    explanationProvider,
+    audioProvider
+);
+```
+
+#### Updates to WordCommand
+Add the same definition formatter provider option to the regular `word` command for consistency.
+
+### 5. Module Dependencies and Exports
+
+#### `zh-learn-domain/module-info.java`
+```java
+module zh.learn.domain {
+    exports com.zhlearn.domain.provider; // Already exports DefinitionFormatterProvider
+}
+```
+
+#### `zh-learn-infrastructure/module-info.java`
+No new exports needed - uses existing `com.zhlearn.infrastructure.common` and `com.zhlearn.infrastructure.dummy` packages.
+
+## Resource Structure
+
+### Prompt Templates
+Following established pattern:
+
+```
+zh-learn-infrastructure/src/main/resources/
+├── single-char/
+│   └── definition/
+│       ├── prompt-template.md                    # CREATED
+│       └── examples/                             # Future: example inputs/outputs
+└── multi-char/
+    └── definition/
+        ├── prompt-template.md                    # CREATED
+        └── examples/                             # Future: example inputs/outputs
+```
+
+### Prompt Content
+
+**Single-Char Prompt** (`single-char/definition/prompt-template.md`):
+- Takes raw definition from Pleco/dictionary
+- Adds minimal HTML formatting (part-of-speech tags, etc.)
+- Expands abbreviations
+- Does NOT change meaning
+
+**Multi-Char Prompt** (`multi-char/definition/prompt-template.md`):
+- Can format existing definitions OR generate new ones
+- Supports complex HTML structure with lists, domains, usage notes
+- More sophisticated formatting and expansion
+
+## Implementation Strategy
+
+### Phase 1: Core Infrastructure
+1. **Create `DefinitionFormatterProvider` interface** in `zh-learn-domain`
+2. **Create configuration classes** for single-char and multi-char prompts
+3. **Create `ConfigurableDefinitionFormatterProvider`** following existing pattern
+4. **Create `DummyDefinitionFormatterProvider`** for testing
+5. **Unit tests** for core functionality
+
+### Phase 2: AI Provider Integration
+1. **Update `AIProviderFactory`** with `createDefinitionFormatterProvider` method
+2. **Add support for all AI providers** (deepseek-chat, glm-4-flash, glm-4.5, qwen variants)
+3. **Integration tests** with dummy and real AI providers
+
+### Phase 3: Service Integration
+1. **Update `WordAnalysisServiceImpl`** to use definition formatter
+2. **Update `ProviderConfiguration`** record
+3. **Integration tests** for the complete pipeline
+
+### Phase 4: CLI Integration
+1. **Update `MainCommand`** with definition formatter provider support
+2. **Update `ParsePlecoCommand`** and `WordCommand` with new option
+3. **End-to-end CLI tests**
+
+### Phase 5: Testing and Documentation
+1. **Comprehensive test coverage** across all layers
+2. **Performance testing** with various AI providers
+3. **Update documentation** (CLAUDE.md, README)
+
+## Detailed Behavior Specification
+
+### Single Character Processing
+- **Input**: Single Chinese character + Optional Pleco definition
+- **AI Processing**: Always uses AI with simple formatting prompt
+- **Behavior**:
+  - If raw definition exists: AI formats it with HTML tags, expands abbreviations
+  - If raw definition is empty: AI may return null or generate minimal definition
+  - Uses `single-char/definition/prompt-template.md`
+
+### Multi-Character Processing
+- **Input**: Multi-character Chinese word + Optional raw definition
+- **AI Processing**: Always uses AI with complex formatting prompt
+- **Behavior**:
+  - If raw definition exists: AI formats and enhances it significantly
+  - If raw definition is empty: AI generates complete new definition
+  - Uses `multi-char/definition/prompt-template.md`
+  - Supports complex HTML with lists, domains, usage markers
+
+### Integration with Parse-Pleco
+- **Provider selection**: Choose AI backend via `--definition-formatter-provider`
+- **Default**: "deepseek-chat" (consistent with other providers)
+- **Pipeline**:
+  1. `DictionaryDefinitionProvider` gets raw definition from Pleco export
+  2. `DefinitionFormatterProvider` formats the raw definition using selected AI service
+  3. Formatted definition used in final `WordAnalysis`
+
+### Provider Names and Backends
+All existing AI providers supported:
+- `dummy` - Test implementation
+- `deepseek-chat` - DeepSeek Chat API
+- `glm-4-flash` - Zhipu GLM-4 Flash
+- `glm-4.5` - Zhipu GLM-4.5
+- `qwen-max`, `qwen-plus`, `qwen-turbo` - Alibaba Qwen variants
+
+## Error Handling
+
+### Fail-Fast Philosophy Compliance
+- **Missing API keys**: Fail immediately during provider creation
+- **Invalid provider names**: Fail during factory method call
+- **AI provider errors**: Let exceptions bubble up, don't swallow
+- **Malformed prompts**: Fail during resource loading
+
+### Graceful Degradation
+- **Definition formatter failure**: Fall back to raw definition if available
+- **No raw definition + formatter failure**: Return null Definition
+- **Invalid AI responses**: Let responseMapper handle validation
+
+## Testing Strategy
+
+### Unit Tests
+- `DefinitionFormatterProviderTest` interface compliance tests
+- `ConfigurableDefinitionFormatterProviderTest` for single/multi-char logic
+- `AIProviderFactoryTest` for new provider creation method
+- `DummyDefinitionFormatterProviderTest` for test implementation
+
+### Integration Tests
+- End-to-end tests with dummy providers
+- Parse-pleco command tests with various AI backends
+- WordAnalysisService tests with definition formatting pipeline
+- Resource loading tests for prompt templates
+
+### Performance Tests
+- AI provider response time measurements
+- Parallel processing with definition formatting
+- Memory usage with large Pleco export files
+
+## Constitutional Compliance
+
+### Modular Architecture ✓
+- Clear module boundaries maintained
+- No cross-layer dependencies
+- Minimal exports from `module-info.java`
+- Follows established provider pattern
+
+### Fail-Fast Philosophy ✓
+- No fallbacks unless explicitly requested
+- Exceptions bubble up rather than being swallowed
+- Fast failure on configuration errors
+- Clear error messages
+
+### Test-First Development ✓
+- Unit tests for each new component
+- Integration tests for provider interactions
+- End-to-end CLI tests
+- Dummy implementations for testing
+
+### CLI-First Interface ✓
+- Command-line options for provider selection
+- Interactive terminal support maintained
+- Consistent with existing CLI patterns
+- Help text follows established format
+
+### Provider Pattern ✓
+- Follows established provider interface pattern
+- Configurable and swappable implementations
+- Clear separation of concerns
+- Consistent with ExampleProvider, ExplanationProvider, etc.
+
+## File Structure
+
+```
+zh-learn-domain/
+└── src/main/java/com/zhlearn/domain/provider/
+    └── DefinitionFormatterProvider.java                                          # NEW
+
+zh-learn-infrastructure/
+├── src/main/java/com/zhlearn/infrastructure/
+│   ├── common/
+│   │   ├── AIProviderFactory.java                                                # UPDATED
+│   │   ├── ConfigurableDefinitionFormatterProvider.java                          # NEW
+│   │   ├── SingleCharDefinitionFormatterProviderConfig.java                      # NEW
+│   │   └── MultiCharDefinitionFormatterProviderConfig.java                       # NEW
+│   └── dummy/
+│       └── DummyDefinitionFormatterProvider.java                                 # NEW
+└── src/main/resources/
+    ├── single-char/definition/
+    │   └── prompt-template.md                                                     # CREATED
+    └── multi-char/definition/
+        └── prompt-template.md                                                     # CREATED
+
+zh-learn-application/
+└── src/main/java/com/zhlearn/application/service/
+    ├── WordAnalysisServiceImpl.java                                              # UPDATED
+    └── ProviderConfiguration.java                                                # UPDATED (record)
+
+zh-learn-cli/
+└── src/main/java/com/zhlearn/cli/
+    ├── MainCommand.java                                                           # UPDATED
+    ├── ParsePlecoCommand.java                                                     # UPDATED
+    └── WordCommand.java                                                           # UPDATED
+```
+

--- a/zh-learn-application/src/main/java/com/zhlearn/application/service/WordAnalysisServiceImpl.java
+++ b/zh-learn-application/src/main/java/com/zhlearn/application/service/WordAnalysisServiceImpl.java
@@ -14,6 +14,7 @@ public class WordAnalysisServiceImpl implements WordAnalysisService {
     private final StructuralDecompositionProvider decompositionProvider;
     private final PinyinProvider pinyinProvider;
     private final DefinitionProvider definitionProvider;
+    private final DefinitionFormatterProvider definitionFormatterProvider;
     private final AudioProvider audioProvider;
 
     public WordAnalysisServiceImpl(ExampleProvider exampleProvider,
@@ -21,12 +22,14 @@ public class WordAnalysisServiceImpl implements WordAnalysisService {
                                   StructuralDecompositionProvider decompositionProvider,
                                   PinyinProvider pinyinProvider,
                                   DefinitionProvider definitionProvider,
+                                  DefinitionFormatterProvider definitionFormatterProvider,
                                   AudioProvider audioProvider) {
         this.exampleProvider = exampleProvider;
         this.explanationProvider = explanationProvider;
         this.decompositionProvider = decompositionProvider;
         this.pinyinProvider = pinyinProvider;
         this.definitionProvider = definitionProvider;
+        this.definitionFormatterProvider = definitionFormatterProvider;
         this.audioProvider = audioProvider;
     }
 
@@ -37,7 +40,20 @@ public class WordAnalysisServiceImpl implements WordAnalysisService {
 
     @Override
     public Definition getDefinition(Hanzi word, String providerName) {
-        return definitionProvider.getDefinition(word);
+        Definition rawDefinition = definitionProvider.getDefinition(word);
+
+        // Format definition if formatter is available
+        if (definitionFormatterProvider != null) {
+            Optional<String> rawText = rawDefinition != null
+                ? Optional.of(rawDefinition.meaning())
+                : Optional.empty();
+            Definition formatted = definitionFormatterProvider.formatDefinition(word, rawText);
+            if (formatted != null) {
+                return formatted;
+            }
+        }
+
+        return rawDefinition;
     }
 
     @Override

--- a/zh-learn-cli/src/main/java/com/zhlearn/cli/AudioCommand.java
+++ b/zh-learn-cli/src/main/java/com/zhlearn/cli/AudioCommand.java
@@ -37,6 +37,7 @@ public class AudioCommand implements Runnable {
             parent.createDecompositionProvider(null), // Use default
             parent.createPinyinProvider(null), // Use default
             parent.createDefinitionProvider(null), // Use default
+            parent.createDefinitionFormatterProvider(null), // Use default
             selectedAudioProvider
         );
 

--- a/zh-learn-cli/src/main/java/com/zhlearn/cli/MainCommand.java
+++ b/zh-learn-cli/src/main/java/com/zhlearn/cli/MainCommand.java
@@ -1,5 +1,6 @@
 package com.zhlearn.cli;
 
+import com.zhlearn.domain.provider.DefinitionFormatterProvider;
 import com.zhlearn.domain.provider.ExampleProvider;
 import com.zhlearn.domain.provider.ExplanationProvider;
 import com.zhlearn.domain.provider.StructuralDecompositionProvider;
@@ -78,6 +79,10 @@ public class MainCommand implements Runnable {
             default -> throw new RuntimeException("Unknown definition provider: " + providerName +
                 ". Available: dummy");
         };
+    }
+
+    public DefinitionFormatterProvider createDefinitionFormatterProvider(String providerName) {
+        return AIProviderFactory.createDefinitionFormatterProvider(providerName);
     }
 
 

--- a/zh-learn-cli/src/main/java/com/zhlearn/cli/ParsePlecoCommand.java
+++ b/zh-learn-cli/src/main/java/com/zhlearn/cli/ParsePlecoCommand.java
@@ -10,6 +10,7 @@ import com.zhlearn.domain.model.Hanzi;
 import com.zhlearn.domain.model.ProviderConfiguration;
 import com.zhlearn.domain.model.WordAnalysis;
 import com.zhlearn.domain.provider.AudioProvider;
+import com.zhlearn.domain.provider.DefinitionFormatterProvider;
 import com.zhlearn.domain.provider.DefinitionProvider;
 import com.zhlearn.domain.provider.ExampleProvider;
 import com.zhlearn.domain.provider.ExplanationProvider;
@@ -63,7 +64,10 @@ public class ParsePlecoCommand implements Runnable {
     
     @Option(names = {"--definition-provider"}, description = "Set specific provider for definition (default: pleco-export). Available: dummy, pleco-export", defaultValue = "pleco-export")
     private String definitionProvider;
-    
+
+    @Option(names = {"--definition-formatter-provider"}, description = "Set specific provider for definition formatting (default: deepseek-chat). Available: dummy, deepseek-chat, glm-4-flash, glm-4.5, qwen-max, qwen-plus, qwen-turbo", defaultValue = "deepseek-chat")
+    private String definitionFormatterProvider;
+
     @Option(names = {"--decomposition-provider"}, description = "Set specific provider for structural decomposition (default: deepseek-chat). Available: dummy, gpt-5-nano, deepseek-chat, qwen3-max, qwen3-plus, qwen3-flash, glm-4-flash, glm-4.5", defaultValue = "deepseek-chat")
     private String decompositionProvider;
 
@@ -120,10 +124,11 @@ public class ParsePlecoCommand implements Runnable {
             StructuralDecompositionProvider decompositionProv = parent.createDecompositionProvider(decompositionProvider);
             PinyinProvider pinyinProv = "pleco-export".equals(pinyinProvider) ? new DictionaryPinyinProvider(dictionary) : parent.createPinyinProvider(pinyinProvider);
             DefinitionProvider definitionProv = "pleco-export".equals(definitionProvider) ? new DictionaryDefinitionProvider(dictionary) : parent.createDefinitionProvider(definitionProvider);
+            DefinitionFormatterProvider defFormatterProv = parent.createDefinitionFormatterProvider(definitionFormatterProvider);
             AudioProvider audioProv = resolveAudioProvider(audioProvider);
 
             WordAnalysisServiceImpl baseService = new WordAnalysisServiceImpl(
-                exampleProv, explanationProv, decompositionProv, pinyinProv, definitionProv, audioProv
+                exampleProv, explanationProv, decompositionProv, pinyinProv, definitionProv, defFormatterProv, audioProv
             );
 
             if (disableParallelism) {
@@ -139,6 +144,7 @@ public class ParsePlecoCommand implements Runnable {
                 exampleProvider,
                 pinyinProvider,
                 definitionProvider,
+                definitionFormatterProvider,
                 decompositionProvider,
                 exampleProvider,
                 explanationProvider,

--- a/zh-learn-cli/src/main/java/com/zhlearn/cli/WordCommand.java
+++ b/zh-learn-cli/src/main/java/com/zhlearn/cli/WordCommand.java
@@ -25,6 +25,9 @@ public class WordCommand implements Runnable {
     @Option(names = {"--definition-provider"}, description = "Set specific provider for definition. Available: dummy", defaultValue = "dummy")
     private String definitionProvider;
 
+    @Option(names = {"--definition-formatter-provider"}, description = "Set specific provider for definition formatting. Available: dummy, deepseek-chat, glm-4-flash, glm-4.5, qwen-max, qwen-plus, qwen-turbo", defaultValue = "deepseek-chat")
+    private String definitionFormatterProvider;
+
     @Option(names = {"--decomposition-provider"}, description = "Set specific provider for structural decomposition. Available: dummy, deepseek-chat, qwen-max, qwen-plus, qwen-turbo, glm-4-flash, glm-4.5", defaultValue = "deepseek-chat")
     private String decompositionProvider;
 
@@ -52,6 +55,7 @@ public class WordCommand implements Runnable {
             parent.createDecompositionProvider(decompositionProvider),
             parent.createPinyinProvider(pinyinProvider),
             parent.createDefinitionProvider(definitionProvider),
+            parent.createDefinitionFormatterProvider(definitionFormatterProvider),
             resolveAudioProvider(audioProvider)
         );
 
@@ -59,6 +63,7 @@ public class WordCommand implements Runnable {
             exampleProvider,
             pinyinProvider,
             definitionProvider,
+            definitionFormatterProvider,
             decompositionProvider,
             exampleProvider,
             explanationProvider,

--- a/zh-learn-domain/src/main/java/com/zhlearn/domain/model/ProviderConfiguration.java
+++ b/zh-learn-domain/src/main/java/com/zhlearn/domain/model/ProviderConfiguration.java
@@ -5,19 +5,21 @@ public class ProviderConfiguration {
     private final String defaultProvider;
     private final String pinyinProvider;
     private final String definitionProvider;
+    private final String definitionFormatterProvider;
     private final String decompositionProvider;
     private final String exampleProvider;
     private final String explanationProvider;
     private final String audioProvider;
     
     public ProviderConfiguration(String defaultProvider) {
-        this(defaultProvider, null, null, null, null, null, null);
+        this(defaultProvider, null, null, null, null, null, null, null);
     }
-    
+
     public ProviderConfiguration(
             String defaultProvider,
             String pinyinProvider,
-            String definitionProvider, 
+            String definitionProvider,
+            String definitionFormatterProvider,
             String decompositionProvider,
             String exampleProvider,
             String explanationProvider,
@@ -25,6 +27,7 @@ public class ProviderConfiguration {
         this.defaultProvider = defaultProvider != null ? defaultProvider : "dummy";
         this.pinyinProvider = pinyinProvider;
         this.definitionProvider = definitionProvider;
+        this.definitionFormatterProvider = definitionFormatterProvider;
         this.decompositionProvider = decompositionProvider;
         this.exampleProvider = exampleProvider;
         this.explanationProvider = explanationProvider;
@@ -39,7 +42,11 @@ public class ProviderConfiguration {
     public String getDefinitionProvider() {
         return definitionProvider != null ? definitionProvider : defaultProvider;
     }
-    
+
+    public String getDefinitionFormatterProvider() {
+        return definitionFormatterProvider != null ? definitionFormatterProvider : defaultProvider;
+    }
+
     public String getDecompositionProvider() {
         return decompositionProvider != null ? decompositionProvider : defaultProvider;
     }
@@ -66,6 +73,7 @@ public class ProviderConfiguration {
                 "default=" + defaultProvider +
                 ", pinyin=" + getPinyinProvider() +
                 ", definition=" + getDefinitionProvider() +
+                ", definitionFormatter=" + getDefinitionFormatterProvider() +
                 ", decomposition=" + getDecompositionProvider() +
                 ", example=" + getExampleProvider() +
                 ", explanation=" + getExplanationProvider() +

--- a/zh-learn-domain/src/main/java/com/zhlearn/domain/provider/DefinitionFormatterProvider.java
+++ b/zh-learn-domain/src/main/java/com/zhlearn/domain/provider/DefinitionFormatterProvider.java
@@ -1,0 +1,22 @@
+package com.zhlearn.domain.provider;
+
+import com.zhlearn.domain.model.Hanzi;
+import com.zhlearn.domain.model.Definition;
+import com.zhlearn.domain.model.ProviderInfo.ProviderType;
+import java.util.Optional;
+
+public interface DefinitionFormatterProvider {
+    String getName();
+    String getDescription();
+    ProviderType getType();
+
+    /**
+     * Format or generate a definition for the given Chinese word using AI.
+     *
+     * @param word The Chinese word to format a definition for
+     * @param rawDefinition Optional raw definition (typically from Pleco export).
+     *                     If present, AI will format it. If empty, AI may generate new definition.
+     * @return AI-formatted HTML definition, or null if cannot process
+     */
+    Definition formatDefinition(Hanzi word, Optional<String> rawDefinition);
+}

--- a/zh-learn-domain/src/test/java/com/zhlearn/domain/model/ProviderConfigurationTest.java
+++ b/zh-learn-domain/src/test/java/com/zhlearn/domain/model/ProviderConfigurationTest.java
@@ -12,6 +12,7 @@ class ProviderConfigurationTest {
             "dummy-default", // default
             null, // pinyin
             null, // definition
+            null, // definitionFormatter
             null, // decomposition
             null, // example
             null, // explanation
@@ -25,6 +26,7 @@ class ProviderConfigurationTest {
     void returnsExplicitAudioProviderWhenProvided() {
         ProviderConfiguration cfg = new ProviderConfiguration(
             "dummy-default",
+            null,
             null,
             null,
             null,

--- a/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/common/AIProviderFactory.java
+++ b/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/common/AIProviderFactory.java
@@ -1,11 +1,14 @@
 package com.zhlearn.infrastructure.common;
 
+import com.zhlearn.domain.model.Definition;
 import com.zhlearn.domain.model.Example;
 import com.zhlearn.domain.model.Explanation;
 import com.zhlearn.domain.model.StructuralDecomposition;
+import com.zhlearn.domain.provider.DefinitionFormatterProvider;
 import com.zhlearn.domain.provider.ExampleProvider;
 import com.zhlearn.domain.provider.ExplanationProvider;
 import com.zhlearn.domain.provider.StructuralDecompositionProvider;
+import com.zhlearn.infrastructure.dummy.DummyDefinitionFormatterProvider;
 import com.zhlearn.infrastructure.dummy.DummyExampleProvider;
 import com.zhlearn.infrastructure.dummy.DummyExplanationProvider;
 import com.zhlearn.infrastructure.dummy.DummyStructuralDecompositionProvider;
@@ -388,5 +391,117 @@ public class AIProviderFactory {
             value = System.getenv(key);
         }
         return value;
+    }
+
+    public static DefinitionFormatterProvider createDefinitionFormatterProvider(String providerName) {
+        if (providerName == null) providerName = "deepseek-chat";
+
+        return switch (providerName) {
+            case "dummy" -> new DummyDefinitionFormatterProvider();
+            case "deepseek-chat" -> {
+                requireAPIKey("DEEPSEEK_API_KEY", providerName);
+                ProviderConfig<Definition> singleConfig = createProviderConfig(
+                    DeepSeekConfig.getApiKey(),
+                    DeepSeekConfig.getBaseUrl(),
+                    "deepseek-chat",
+                    SingleCharDefinitionFormatterProviderConfig.templatePath(),
+                    SingleCharDefinitionFormatterProviderConfig.examplesDirectory(),
+                    SingleCharDefinitionFormatterProviderConfig.responseMapper(),
+                    providerName,
+                    "Failed to format definition from DeepSeek (deepseek-chat)"
+                );
+                ProviderConfig<Definition> multiConfig = createProviderConfig(
+                    DeepSeekConfig.getApiKey(),
+                    DeepSeekConfig.getBaseUrl(),
+                    "deepseek-chat",
+                    MultiCharDefinitionFormatterProviderConfig.templatePath(),
+                    MultiCharDefinitionFormatterProviderConfig.examplesDirectory(),
+                    MultiCharDefinitionFormatterProviderConfig.responseMapper(),
+                    providerName,
+                    "Failed to format definition from DeepSeek (deepseek-chat)"
+                );
+                yield new ConfigurableDefinitionFormatterProvider(singleConfig, multiConfig, providerName, "DeepSeek AI-powered definition formatter");
+            }
+            case "glm-4-flash" -> {
+                requireAPIKey("ZHIPU_API_KEY", providerName);
+                ProviderConfig<Definition> singleConfig = createProviderConfig(
+                    ZhipuConfig.getApiKey(),
+                    ZhipuConfig.getBaseUrl(),
+                    "glm-4-flash",
+                    SingleCharDefinitionFormatterProviderConfig.templatePath(),
+                    SingleCharDefinitionFormatterProviderConfig.examplesDirectory(),
+                    SingleCharDefinitionFormatterProviderConfig.responseMapper(),
+                    providerName,
+                    "Failed to format definition from Zhipu (glm-4-flash)"
+                );
+                ProviderConfig<Definition> multiConfig = createProviderConfig(
+                    ZhipuConfig.getApiKey(),
+                    ZhipuConfig.getBaseUrl(),
+                    "glm-4-flash",
+                    MultiCharDefinitionFormatterProviderConfig.templatePath(),
+                    MultiCharDefinitionFormatterProviderConfig.examplesDirectory(),
+                    MultiCharDefinitionFormatterProviderConfig.responseMapper(),
+                    providerName,
+                    "Failed to format definition from Zhipu (glm-4-flash)"
+                );
+                ZhipuChatModelProvider<Definition> singleDelegate = new ZhipuChatModelProvider<>(singleConfig);
+                ZhipuChatModelProvider<Definition> multiDelegate = new ZhipuChatModelProvider<>(multiConfig);
+                yield new ConfigurableDefinitionFormatterProvider(singleDelegate::process, multiDelegate::process,
+                    providerName, "GLM-4 Flash AI definition formatter");
+            }
+            case "glm-4.5" -> {
+                requireAPIKey("ZHIPU_API_KEY", providerName);
+                ProviderConfig<Definition> singleConfig = createProviderConfig(
+                    ZhipuConfig.getApiKey(),
+                    ZhipuConfig.getBaseUrl(),
+                    "glm-4.5",
+                    SingleCharDefinitionFormatterProviderConfig.templatePath(),
+                    SingleCharDefinitionFormatterProviderConfig.examplesDirectory(),
+                    SingleCharDefinitionFormatterProviderConfig.responseMapper(),
+                    providerName,
+                    "Failed to format definition from Zhipu (glm-4.5)"
+                );
+                ProviderConfig<Definition> multiConfig = createProviderConfig(
+                    ZhipuConfig.getApiKey(),
+                    ZhipuConfig.getBaseUrl(),
+                    "glm-4.5",
+                    MultiCharDefinitionFormatterProviderConfig.templatePath(),
+                    MultiCharDefinitionFormatterProviderConfig.examplesDirectory(),
+                    MultiCharDefinitionFormatterProviderConfig.responseMapper(),
+                    providerName,
+                    "Failed to format definition from Zhipu (glm-4.5)"
+                );
+                ZhipuChatModelProvider<Definition> singleDelegate = new ZhipuChatModelProvider<>(singleConfig);
+                ZhipuChatModelProvider<Definition> multiDelegate = new ZhipuChatModelProvider<>(multiConfig);
+                yield new ConfigurableDefinitionFormatterProvider(singleDelegate::process, multiDelegate::process,
+                    providerName, "GLM-4.5 AI definition formatter");
+            }
+            case "qwen-max", "qwen-plus", "qwen-turbo" -> {
+                requireAPIKey("DASHSCOPE_API_KEY", providerName);
+                ProviderConfig<Definition> singleConfig = createProviderConfig(
+                    DashScopeConfig.getApiKey(),
+                    DashScopeConfig.getBaseUrl(),
+                    providerName,
+                    SingleCharDefinitionFormatterProviderConfig.templatePath(),
+                    SingleCharDefinitionFormatterProviderConfig.examplesDirectory(),
+                    SingleCharDefinitionFormatterProviderConfig.responseMapper(),
+                    providerName,
+                    "Failed to format definition from DashScope (" + providerName + ")"
+                );
+                ProviderConfig<Definition> multiConfig = createProviderConfig(
+                    DashScopeConfig.getApiKey(),
+                    DashScopeConfig.getBaseUrl(),
+                    providerName,
+                    MultiCharDefinitionFormatterProviderConfig.templatePath(),
+                    MultiCharDefinitionFormatterProviderConfig.examplesDirectory(),
+                    MultiCharDefinitionFormatterProviderConfig.responseMapper(),
+                    providerName,
+                    "Failed to format definition from DashScope (" + providerName + ")"
+                );
+                yield new ConfigurableDefinitionFormatterProvider(singleConfig, multiConfig, providerName, "Qwen AI definition formatter (" + providerName + ")");
+            }
+            default -> throw new RuntimeException("Unknown definition formatter provider: " + providerName +
+                ". Available: dummy, deepseek-chat, glm-4-flash, glm-4.5, qwen-max, qwen-plus, qwen-turbo");
+        };
     }
 }

--- a/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/common/ConfigurableDefinitionFormatterProvider.java
+++ b/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/common/ConfigurableDefinitionFormatterProvider.java
@@ -1,0 +1,117 @@
+package com.zhlearn.infrastructure.common;
+
+import com.zhlearn.domain.model.Definition;
+import com.zhlearn.domain.model.Hanzi;
+import com.zhlearn.domain.model.ProviderInfo.ProviderType;
+import com.zhlearn.domain.model.WordType;
+import com.zhlearn.domain.provider.DefinitionFormatterProvider;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+public class ConfigurableDefinitionFormatterProvider implements DefinitionFormatterProvider {
+
+    private final BiFunction<Hanzi, Optional<String>, Definition> singleCharProcessor;
+    private final BiFunction<Hanzi, Optional<String>, Definition> multiCharProcessor;
+    private final Optional<ProviderConfig<Definition>> singleCharConfig;
+    private final Optional<ProviderConfig<Definition>> multiCharConfig;
+    private final String name;
+    private final String description;
+
+    public ConfigurableDefinitionFormatterProvider(ProviderConfig<Definition> config, String name, String description) {
+        this(new GenericChatModelProvider<>(config)::process, new GenericChatModelProvider<>(config)::process,
+            Optional.of(config), Optional.of(config), name, description);
+    }
+
+    public ConfigurableDefinitionFormatterProvider(GenericChatModelProvider<Definition> provider, String name, String description) {
+        this(provider::process, provider::process, Optional.empty(), Optional.empty(), name, description);
+    }
+
+    public ConfigurableDefinitionFormatterProvider(ProviderConfig<Definition> singleCharConfig,
+                                       ProviderConfig<Definition> multiCharConfig,
+                                       String name,
+                                       String description) {
+        this(new GenericChatModelProvider<>(singleCharConfig)::process,
+            new GenericChatModelProvider<>(multiCharConfig)::process,
+            Optional.of(singleCharConfig), Optional.of(multiCharConfig), name, description);
+    }
+
+    public ConfigurableDefinitionFormatterProvider(GenericChatModelProvider<Definition> singleCharProvider,
+                                       GenericChatModelProvider<Definition> multiCharProvider,
+                                       String name,
+                                       String description) {
+        this(singleCharProvider::process, multiCharProvider::process,
+            Optional.empty(), Optional.empty(), name, description);
+    }
+
+    public ConfigurableDefinitionFormatterProvider(BiFunction<Hanzi, Optional<String>, Definition> processor, String name, String description) {
+        this(processor, processor, Optional.empty(), Optional.empty(), name, description);
+    }
+
+    public ConfigurableDefinitionFormatterProvider(BiFunction<Hanzi, Optional<String>, Definition> singleCharProcessor,
+                                       BiFunction<Hanzi, Optional<String>, Definition> multiCharProcessor,
+                                       String name,
+                                       String description) {
+        this(singleCharProcessor, multiCharProcessor, Optional.empty(), Optional.empty(), name, description);
+    }
+
+    public ConfigurableDefinitionFormatterProvider(BiFunction<Hanzi, Optional<String>, Definition> singleCharProcessor,
+                                       ProviderConfig<Definition> singleCharConfig,
+                                       BiFunction<Hanzi, Optional<String>, Definition> multiCharProcessor,
+                                       ProviderConfig<Definition> multiCharConfig,
+                                       String name,
+                                       String description) {
+        this(singleCharProcessor, multiCharProcessor,
+            Optional.of(singleCharConfig), Optional.of(multiCharConfig), name, description);
+    }
+
+    ConfigurableDefinitionFormatterProvider(BiFunction<Hanzi, Optional<String>, Definition> singleCharProcessor,
+                                BiFunction<Hanzi, Optional<String>, Definition> multiCharProcessor,
+                                Optional<ProviderConfig<Definition>> singleCharConfig,
+                                Optional<ProviderConfig<Definition>> multiCharConfig,
+                                String name,
+                                String description) {
+        this.singleCharProcessor = singleCharProcessor;
+        this.multiCharProcessor = multiCharProcessor;
+        this.singleCharConfig = singleCharConfig;
+        this.multiCharConfig = multiCharConfig;
+        this.name = name;
+        this.description = description;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public ProviderType getType() {
+        return ProviderType.AI;
+    }
+
+    @Override
+    public Definition formatDefinition(Hanzi word, Optional<String> rawDefinition) {
+        WordType type = WordType.from(word);
+        return selectProcessor(type).apply(word, rawDefinition);
+    }
+
+    Optional<ProviderConfig<Definition>> singleCharConfig() {
+        return singleCharConfig;
+    }
+
+    Optional<ProviderConfig<Definition>> multiCharConfig() {
+        return multiCharConfig;
+    }
+
+    private BiFunction<Hanzi, Optional<String>, Definition> selectProcessor(WordType type) {
+        return switch (type) {
+            case SINGLE_CHARACTER -> singleCharProcessor;
+            case MULTI_CHARACTER -> multiCharProcessor;
+        };
+    }
+}

--- a/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/common/DefinitionResponseMapper.java
+++ b/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/common/DefinitionResponseMapper.java
@@ -1,0 +1,70 @@
+package com.zhlearn.infrastructure.common;
+
+import com.zhlearn.domain.model.Definition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.Function;
+
+public class DefinitionResponseMapper implements Function<String, Definition> {
+
+    private static final Logger log = LoggerFactory.getLogger(DefinitionResponseMapper.class);
+
+    @Override
+    public Definition apply(String response) {
+        try {
+            // Strip markdown code blocks if present
+            String cleanedResponse = stripMarkdownCodeBlocks(response);
+
+            // Trim whitespace and return as Definition
+            String trimmed = cleanedResponse.trim();
+            if (trimmed.isEmpty()) {
+                throw new IllegalStateException("Empty definition response");
+            }
+
+            return new Definition(trimmed);
+
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            String errorMessage = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+            log.warn("Failed to parse definition response: {}", errorMessage);
+            log.debug("Original response: {}", response);
+            throw new RuntimeException("Failed to parse definition response: " + errorMessage, e);
+        }
+    }
+
+    private String stripMarkdownCodeBlocks(String input) {
+        if (input == null) {
+            return null;
+        }
+
+        String trimmed = input.trim();
+
+        // Check if the input starts with ```html or ``` and ends with ```
+        if (trimmed.startsWith("```html") && trimmed.endsWith("```")) {
+            // Remove ```html from the start and ``` from the end
+            int startIndex = trimmed.indexOf('\n', 7); // Find first newline after ```html
+            if (startIndex == -1) {
+                startIndex = 7; // No newline found, start after ```html
+            } else {
+                startIndex++; // Move past the newline
+            }
+            int endIndex = trimmed.lastIndexOf("```");
+            return trimmed.substring(startIndex, endIndex).trim();
+        } else if (trimmed.startsWith("```") && trimmed.endsWith("```")) {
+            // Generic code block without html specifier
+            int startIndex = trimmed.indexOf('\n', 3); // Find first newline after ```
+            if (startIndex == -1) {
+                startIndex = 3; // No newline found, start after ```
+            } else {
+                startIndex++; // Move past the newline
+            }
+            int endIndex = trimmed.lastIndexOf("```");
+            return trimmed.substring(startIndex, endIndex).trim();
+        }
+
+        // No markdown code blocks found, return as is
+        return input;
+    }
+}

--- a/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/common/MultiCharDefinitionFormatterProviderConfig.java
+++ b/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/common/MultiCharDefinitionFormatterProviderConfig.java
@@ -1,0 +1,37 @@
+package com.zhlearn.infrastructure.common;
+
+import com.zhlearn.domain.model.Definition;
+
+import java.util.function.Function;
+
+public final class MultiCharDefinitionFormatterProviderConfig {
+
+    private static final String TEMPLATE_PATH = "/multi-char/definition/prompt-template.md";
+    private static final String EXAMPLES_DIRECTORY = "/multi-char/definition/examples/";
+    private static final Function<String, Definition> RESPONSE_MAPPER = new DefinitionResponseMapper();
+    private static final Double DEFAULT_TEMPERATURE = 0.3;
+    private static final Integer DEFAULT_MAX_TOKENS = 4000;
+
+    private MultiCharDefinitionFormatterProviderConfig() {
+    }
+
+    public static String templatePath() {
+        return TEMPLATE_PATH;
+    }
+
+    public static String examplesDirectory() {
+        return EXAMPLES_DIRECTORY;
+    }
+
+    public static Function<String, Definition> responseMapper() {
+        return RESPONSE_MAPPER;
+    }
+
+    public static Double defaultTemperature() {
+        return DEFAULT_TEMPERATURE;
+    }
+
+    public static Integer defaultMaxTokens() {
+        return DEFAULT_MAX_TOKENS;
+    }
+}

--- a/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/common/SingleCharDefinitionFormatterProviderConfig.java
+++ b/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/common/SingleCharDefinitionFormatterProviderConfig.java
@@ -1,0 +1,37 @@
+package com.zhlearn.infrastructure.common;
+
+import com.zhlearn.domain.model.Definition;
+
+import java.util.function.Function;
+
+public final class SingleCharDefinitionFormatterProviderConfig {
+
+    private static final String TEMPLATE_PATH = "/single-char/definition/prompt-template.md";
+    private static final String EXAMPLES_DIRECTORY = "/single-char/definition/examples/";
+    private static final Function<String, Definition> RESPONSE_MAPPER = new DefinitionResponseMapper();
+    private static final Double DEFAULT_TEMPERATURE = 0.3;
+    private static final Integer DEFAULT_MAX_TOKENS = 4000;
+
+    private SingleCharDefinitionFormatterProviderConfig() {
+    }
+
+    public static String templatePath() {
+        return TEMPLATE_PATH;
+    }
+
+    public static String examplesDirectory() {
+        return EXAMPLES_DIRECTORY;
+    }
+
+    public static Function<String, Definition> responseMapper() {
+        return RESPONSE_MAPPER;
+    }
+
+    public static Double defaultTemperature() {
+        return DEFAULT_TEMPERATURE;
+    }
+
+    public static Integer defaultMaxTokens() {
+        return DEFAULT_MAX_TOKENS;
+    }
+}

--- a/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/dummy/DummyDefinitionFormatterProvider.java
+++ b/zh-learn-infrastructure/src/main/java/com/zhlearn/infrastructure/dummy/DummyDefinitionFormatterProvider.java
@@ -1,0 +1,32 @@
+package com.zhlearn.infrastructure.dummy;
+
+import com.zhlearn.domain.model.Definition;
+import com.zhlearn.domain.model.Hanzi;
+import com.zhlearn.domain.model.ProviderInfo.ProviderType;
+import com.zhlearn.domain.provider.DefinitionFormatterProvider;
+
+import java.util.Optional;
+
+public class DummyDefinitionFormatterProvider implements DefinitionFormatterProvider {
+
+    @Override
+    public String getName() {
+        return "dummy";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Test provider that returns dummy formatted definitions for development and testing";
+    }
+
+    @Override
+    public ProviderType getType() {
+        return ProviderType.DUMMY;
+    }
+
+    @Override
+    public Definition formatDefinition(Hanzi word, Optional<String> rawDefinition) {
+        String formatted = rawDefinition.orElse("dummy definition for " + word.characters());
+        return new Definition("<span class=\"part-of-speech\">dummy</span> " + formatted);
+    }
+}

--- a/zh-learn-infrastructure/src/main/resources/multi-char/definition/prompt-template.md
+++ b/zh-learn-infrastructure/src/main/resources/multi-char/definition/prompt-template.md
@@ -1,69 +1,116 @@
-## Input Format
-You will receive:
-- **Chinese word**: The multi-character Chinese word/phrase being defined
-- **Original content (optional)**: The raw definition/meaning from Pleco export
+# Chinese Multi-Character Word Definition Formatting
 
-Format the content so it looks like the exemples:
+Format the definition for Chinese word: **{WORD}**
+{CONTEXT}
 
-```html 
-<span class="part-of-speech">noun</span> snare; trap
-``` 
+## Task
+ONLY format the provided raw definition - DO NOT generate new content under any circumstances. Focus on clean HTML presentation and expanding abbreviations to full words.
 
-```html 
+## Input Definition
+{RAW_DEFINITION}
+
+## Output Format
+Return your response as well-structured HTML using the following patterns:
+
+### Simple Definition
+```html
+<span class="part-of-speech">part of speech</span> definition text
+```
+
+### Complex Definition with Multiple Meanings
+```html
 <span class="part-of-speech">verb</span> <span class="usage">colloquial</span>
 <ol>
     <li>boast; brag; talk big</li>
     <li><span class="usage dialect">dialect</span> chat; talk casually</li>
 </ol>
-```html 
+```
 
+### Domain-Specific Definitions
+```html
 <span class="part-of-speech">noun</span> <span class="domain">anatomy</span> vein
-``` 
+```
 
-
-```html 
-<span class="part-of-speech">verb</span> 
-<ol>
-    <li>entice; tempt; seduce; lure</li>
-    <li>attract; allure</li>
-</ol>
-``` 
-
-```html 
+### Multiple Parts of Speech
+```html
 <span class="part-of-speech">noun</span>
 <ol>
-    <li> <span class="domain">medicine</span> miscarriage; abortion</li>
+    <li><span class="domain">medicine</span> miscarriage; abortion</li>
 </ol>
 <span class="part-of-speech">verb</span>
 <ol>
     <li><span class="domain">medicine</span> (of a woman) have a miscarriage; miscarry; abort</li>
     <li><span class="usage">figurative</span> (of a plan, etc.) miscarry; fall through; abort</li>
 </ol>
-``` 
-
-
-if a usage or domain is in parentheses, remove the parentheses, eg:
-
-input:
-```
-Chinese Word: 高维
-Original Content: (math.) higher dimensional
 ```
 
-desired output:
-<span class="domain">mathematics</span> higher dimensional
+## Guidelines
 
-If you receive Original Content (i.e, a pleco dictionary definition):
-Do not add anything that changes meaning, just add the formatting and expand abbreviations.
+### Multi-Character Processing
+- Use numbered lists (`<ol>`) for distinct meanings
+- Add part-of-speech tagging using `<span class="part-of-speech">` tags
+- Mark usage notes with `<span class="usage">` or specific classes like `<span class="usage dialect">`
+- Mark domains with `<span class="domain">` tags
+- Expand common abbreviations
+- Use semantic HTML structure
 
-If you DO NOT receive Original Content (and only in that case), create a definition in the style above yourself.
+### HTML Structure Rules
+- Use proper HTML5 semantics
+- Ensure all tags are properly closed
+- Use `<ol>` for ordered lists of meanings
+- Use `<li>` for individual definitions
+- Nest spans appropriately for usage/domain markers
 
-Provide correct well formed html snippets in the response. 
+### Class Names
+- `part-of-speech`: For grammatical categories
+- `usage`: For general usage notes
+- `usage dialect`: For dialect-specific usage
+- `usage colloquial`: For colloquial usage
+- `usage figurative`: For figurative usage
+- `domain`: For subject domains
 
+### Domain Expansion
+Expand domain abbreviations:
+- math. → mathematics
+- med. → medicine
+- anat. → anatomy
+- pharm. → pharmacy
+- ling. → linguistics
+- ecol. → ecology
+- chem. → chemistry
+- phys. → physics
 
-## Common domain words (non exhaustive)
-ecology
-anatomy
-pharmacy
-linguistics
-mathematics
+### Abbreviation Expansion - MANDATORY
+ALWAYS expand the following abbreviations to their full word forms:
+- adj. → adjective
+- adv. → adverb
+- conj. → conjunction
+- interj. → interjection
+- n. → noun
+- prep. → preposition
+- v. → verb
+- etc. → and so forth
+- i.e. → that is
+- e.g. → for example
+
+### Parentheses Handling
+Remove parentheses from usage/domain markers:
+- Input: "(math.) higher dimensional"
+- Output: `<span class="domain">mathematics</span> higher dimensional`
+
+### Content Preservation - CRITICAL
+- IMPORTANT: Preserve the original meaning exactly. Only add HTML formatting and expand abbreviations.
+- NEVER add new definitions, meanings, or explanations not present in the original.
+- If the original definition is brief or simple, keep it brief - only format what's provided.
+- DO NOT elaborate, expand, or add examples unless they exist in the original.
+
+### What NOT To Do
+- WRONG: Generate new definitions for words like 牙套
+- WRONG: Keep abbreviations like "adj." or "n." in their abbreviated form
+- WRONG: Add meanings not present in the original definition
+- WRONG: Include explanatory text or comments in your output
+
+{EXAMPLES}
+
+Now format the definition for: **{WORD}**
+Remember: output only clean HTML (no extra prose or explanations).

--- a/zh-learn-infrastructure/src/main/resources/multi-char/definition/prompt-template.md
+++ b/zh-learn-infrastructure/src/main/resources/multi-char/definition/prompt-template.md
@@ -1,0 +1,69 @@
+## Input Format
+You will receive:
+- **Chinese word**: The multi-character Chinese word/phrase being defined
+- **Original content (optional)**: The raw definition/meaning from Pleco export
+
+Format the content so it looks like the exemples:
+
+```html 
+<span class="part-of-speech">noun</span> snare; trap
+``` 
+
+```html 
+<span class="part-of-speech">verb</span> <span class="usage">colloquial</span>
+<ol>
+    <li>boast; brag; talk big</li>
+    <li><span class="usage dialect">dialect</span> chat; talk casually</li>
+</ol>
+```html 
+
+<span class="part-of-speech">noun</span> <span class="domain">anatomy</span> vein
+``` 
+
+
+```html 
+<span class="part-of-speech">verb</span> 
+<ol>
+    <li>entice; tempt; seduce; lure</li>
+    <li>attract; allure</li>
+</ol>
+``` 
+
+```html 
+<span class="part-of-speech">noun</span>
+<ol>
+    <li> <span class="domain">medicine</span> miscarriage; abortion</li>
+</ol>
+<span class="part-of-speech">verb</span>
+<ol>
+    <li><span class="domain">medicine</span> (of a woman) have a miscarriage; miscarry; abort</li>
+    <li><span class="usage">figurative</span> (of a plan, etc.) miscarry; fall through; abort</li>
+</ol>
+``` 
+
+
+if a usage or domain is in parentheses, remove the parentheses, eg:
+
+input:
+```
+Chinese Word: 高维
+Original Content: (math.) higher dimensional
+```
+
+desired output:
+<span class="domain">mathematics</span> higher dimensional
+
+If you receive Original Content (i.e, a pleco dictionary definition):
+Do not add anything that changes meaning, just add the formatting and expand abbreviations.
+
+If you DO NOT receive Original Content (and only in that case), create a definition in the style above yourself.
+
+Provide correct well formed html snippets in the response. 
+
+
+## Common domain words (non exhaustive)
+ecology
+anatomy
+pharmacy
+linguistics
+mathematics

--- a/zh-learn-infrastructure/src/main/resources/single-char/definition/prompt-template.md
+++ b/zh-learn-infrastructure/src/main/resources/single-char/definition/prompt-template.md
@@ -1,0 +1,27 @@
+## Input Format
+You will receive:
+- **Chinese character**: The single Chinese character being defined
+- **Original content**: The raw definition/meaning from Pleco export
+
+Format the content so it looks like the exemples, representing a meaning tree:
+
+```html
+(orig.) to swindle s.o, cheat → fake; not genuine
+```
+
+```html
+(orig.) to make clothing → to cut, to trim ⇒ to reduce, to cut back ⇒ to make a decision or judgement
+```
+
+```html
+(orig.) to work together → to agree, be in harmony → to assist, help
+```
+
+```html
+(orig.) to weigh → weight ⇒ influence ⟾ rights
+```
+
+If you receive Original Content (i.e, a pleco dictionary definition):
+Do not add anything that changes meaning, just add the formatting and expand abbreviations.
+
+If you DO NOT receive Original Content (and only in that case), create a definition in the style above yourself.

--- a/zh-learn-infrastructure/src/main/resources/single-char/definition/prompt-template.md
+++ b/zh-learn-infrastructure/src/main/resources/single-char/definition/prompt-template.md
@@ -1,27 +1,85 @@
-## Input Format
-You will receive:
-- **Chinese character**: The single Chinese character being defined
-- **Original content**: The raw definition/meaning from Pleco export
+# Chinese Character Definition Formatting
 
-Format the content so it looks like the exemples, representing a meaning tree:
+Format the definition for Chinese character: **{WORD}**
+{CONTEXT}
 
-```html
-(orig.) to swindle s.o, cheat → fake; not genuine
-```
+## Task
+ONLY format the provided raw definition - DO NOT generate new content under any circumstances. Focus on clean HTML presentation and expanding abbreviations to full words.
 
-```html
-(orig.) to make clothing → to cut, to trim ⇒ to reduce, to cut back ⇒ to make a decision or judgement
-```
+## Input Definition
+{RAW_DEFINITION}
 
-```html
-(orig.) to work together → to agree, be in harmony → to assist, help
-```
+## Output Format
+Return your response as a clean HTML definition using the following structure:
 
 ```html
-(orig.) to weigh → weight ⇒ influence ⟾ rights
+<span class="part-of-speech">part of speech</span> formatted definition text with appropriate HTML structure
 ```
 
-If you receive Original Content (i.e, a pleco dictionary definition):
-Do not add anything that changes meaning, just add the formatting and expand abbreviations.
+## Guidelines
 
-If you DO NOT receive Original Content (and only in that case), create a definition in the style above yourself.
+### Single Character Processing
+- For single characters, keep definitions concise and focused
+- Add part-of-speech tagging using `<span class="part-of-speech">` tags
+- ALWAYS expand abbreviations to their full word forms - NEVER keep abbreviated forms
+- Use semantic HTML where appropriate:
+  - `<em>` for emphasis
+  - `<strong>` for key terms
+  - Use semicolons to separate different meanings
+  - Use commas to separate related concepts
+
+### HTML Structure Rules
+- Always include part-of-speech tagging as the first element
+- Use proper HTML semantics
+- Keep the structure clean and readable
+- Avoid complex nested structures for single characters
+- Ensure proper closing of all HTML tags
+
+### Abbreviation Expansion - MANDATORY
+ALWAYS expand the following abbreviations to their full word forms:
+- adj. → adjective
+- adv. → adverb
+- conj. → conjunction
+- interj. → interjection
+- n. → noun
+- prep. → preposition
+- v. → verb
+- etc. → and so forth
+- i.e. → that is
+- e.g. → for example
+
+### Content Preservation - CRITICAL
+- IMPORTANT: Preserve the original meaning exactly. Only add HTML formatting and expand abbreviations.
+- NEVER add new definitions, meanings, or explanations not present in the original.
+- If the original definition is brief or simple, keep it brief - only format what's provided.
+- DO NOT elaborate, expand, or add examples unless they exist in the original.
+
+### Example Outputs
+For input: "v. to estimate; to assess; evaluation"
+Output:
+```html
+<span class="part-of-speech">verb</span> to estimate; to assess; evaluation
+```
+
+For input: "n. ancient Chinese musical instrument; bell"
+Output:
+```html
+<span class="part-of-speech">noun</span> ancient Chinese musical instrument; bell
+```
+
+For input: "adj. flat, level, even"
+Output:
+```html
+<span class="part-of-speech">adjective</span> flat, level, even
+```
+
+### What NOT To Do
+- WRONG: Generate new definitions for characters like 牙套
+- WRONG: Keep abbreviations like "adj." or "n." in their abbreviated form
+- WRONG: Add meanings not present in the original definition
+- WRONG: Include explanatory text or comments in your output
+
+{EXAMPLES}
+
+Now format the definition for: **{WORD}**
+Remember: output only clean HTML (no extra prose or explanations).


### PR DESCRIPTION
## Summary
- Improved single-char and multi-char definition formatter prompt templates with stronger constraints
- Added explicit "DO NOT generate new content" directive to prevent AI from creating new definitions
- Made abbreviation expansion mandatory with comprehensive mapping (adj. → adjective, etc.)
- Added content preservation rules to ensure original meaning is maintained exactly
- Included "What NOT To Do" sections with specific examples of wrong behavior
- Addresses issues where AI was generating new content for 牙套 and not expanding abbreviations for 平坦

## Test plan
- Test with 牙套 to ensure no new content generation occurs
- Test with 平坦 to ensure adj. properly expands to adjective
- Verify existing functionality still works with other characters
- Run integration tests to ensure overall system functionality

🤖 Generated with [Claude Code](https://claude.ai/code)