### PR TITLE
fix: change default providers to dummy

### DIFF
--- a/zh-learn-cli/src/main/java/com/zhlearn/cli/WordCommand.java
+++ b/zh-learn-cli/src/main/java/com/zhlearn/cli/WordCommand.java
@@ -25,16 +25,16 @@ public class WordCommand implements Runnable {
     @Option(names = {"--definition-provider"}, description = "Set specific provider for definition. Available: dummy", defaultValue = "dummy")
     private String definitionProvider;
 
-    @Option(names = {"--definition-formatter-provider"}, description = "Set specific provider for definition formatting. Available: dummy, deepseek-chat, glm-4-flash, glm-4.5, qwen-max, qwen-plus, qwen-turbo, openrouter", defaultValue = "deepseek-chat")
+    @Option(names = {"--definition-formatter-provider"}, description = "Set specific provider for definition formatting. Available: dummy, deepseek-chat, glm-4-flash, glm-4.5, qwen-max, qwen-plus, qwen-turbo, openrouter", defaultValue = "dummy")
     private String definitionFormatterProvider;
 
-    @Option(names = {"--decomposition-provider"}, description = "Set specific provider for structural decomposition. Available: dummy, deepseek-chat, qwen-max, qwen-plus, qwen-turbo, glm-4-flash, glm-4.5, openrouter", defaultValue = "deepseek-chat")
+    @Option(names = {"--decomposition-provider"}, description = "Set specific provider for structural decomposition. Available: dummy, deepseek-chat, qwen-max, qwen-plus, qwen-turbo, glm-4-flash, glm-4.5, openrouter", defaultValue = "dummy")
     private String decompositionProvider;
 
-    @Option(names = {"--example-provider"}, description = "Set specific provider for examples. Available: dummy, deepseek-chat, qwen-max, qwen-plus, qwen-turbo, glm-4-flash, glm-4.5, openrouter", defaultValue = "deepseek-chat")
+    @Option(names = {"--example-provider"}, description = "Set specific provider for examples. Available: dummy, deepseek-chat, qwen-max, qwen-plus, qwen-turbo, glm-4-flash, glm-4.5, openrouter", defaultValue = "dummy")
     private String exampleProvider;
 
-    @Option(names = {"--explanation-provider"}, description = "Set specific provider for explanation. Available: dummy, deepseek-chat, qwen-max, qwen-plus, qwen-turbo, glm-4-flash, glm-4.5, openrouter", defaultValue = "deepseek-chat")
+    @Option(names = {"--explanation-provider"}, description = "Set specific provider for explanation. Available: dummy, deepseek-chat, qwen-max, qwen-plus, qwen-turbo, glm-4-flash, glm-4.5, openrouter", defaultValue = "dummy")
     private String explanationProvider;
     
     @Option(names = {"--audio-provider"}, description = "Set specific provider for audio pronunciation. Available: anki, forvo, qwen-tts", defaultValue = "anki")


### PR DESCRIPTION
## Summary
- Changed default provider values in WordCommand from deepseek-chat to dummy for definition formatting, decomposition, examples, and explanation
- This prevents accidental API usage when no provider is specified
- All tests pass and build succeeds

## Test plan
- [x] All tests pass (136 tests total)
- [x] Build succeeds with `mvn clean package`
- [x] CLI works with dummy providers