### PR TITLE
refactor: use op inject for faster .envrc loading

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,38 +1,15 @@
 #!/bin/bash
 
-# Load GPT credentials from 1Password
-export OPENAI_API_KEY="$(op read "op://Personal/GPT_CHINESE/credential")"
+# Load all secrets from 1Password in a single call using op inject
+# This is faster and triggers only one permission prompt instead of 12
+eval "$(op inject -i .envrc.tpl)"
 
-# Load Gemini credentials from 1Password
-export GEMINI_API_KEY="$(op read "op://Personal/GEMINI_API_KEY/credential")"
-
-# Load ChatGLM credentials from 1Password
-export CHAT_GLM_API_KEY="$(op read "op://Personal/CHAT_GLM_API_KEY/credential")"
-# Backward-compat alias for ChatGLM via z.ai
+# Backward-compat aliases for ChatGLM via z.ai
 export ZAI_API_KEY="${ZAI_API_KEY:-$CHAT_GLM_API_KEY}"
 export ZHIPU_API_KEY="${ZAI_API_KEY:-$CHAT_GLM_API_KEY}"
 
-export DASHSCOPE_API_KEY="$(op read "op://Personal/DASHSCOPE_API_KEY_SINGAPORE/credential")"
-
-export TENCENT_SECRET_ID="$(op read "op://Personal/TENCENT_ZH_LEARN/username")"
-export TENCENT_API_KEY="$(op read "op://Personal/TENCENT_ZH_LEARN/credential")"
+# Alias for Tencent
 export TENCENT_SECRET_KEY=$TENCENT_API_KEY
 
-# Load DeepSeek credentials from 1Password
-export DEEPSEEK_API_KEY="$(op read "op://Personal/DEEPSEEK_API_KEY/credential")"
-
-export AZURE_LANGUAGE_ENDPOINT="$(op read "op://Personal/AZURE_COGNITIVE_SERVICES/endpoint")"
-export AZURE_LANGUAGE_KEY="$(op read "op://Personal/AZURE_COGNITIVE_SERVICES/credential")"
-
-export FORVO_API_KEY="$(op read "op://Personal/FORVO_API_KEY/credential")"
-
-export OPENROUTER_API_KEY="$(op read "op://Personal/OPENROUTER_API_KEY/credential")"
-
-# Load MiniMax credentials from 1Password
-export MINIMAX_GROUP_ID="$(op read "op://Personal/MINIMAX_API_KEY/username")"
-export MINIMAX_API_KEY="$(op read "op://Personal/MINIMAX_API_KEY/credential")"
-
-# Load Google Custom Search API credentials from 1Password
-export GOOGLE_SEARCH_API_KEY="$(op read "op://Personal/GOOGLE_SEARCH_API_KEY/credential")"
 # Search Engine ID is not a secret
 export GOOGLE_SEARCH_ENGINE_ID="8657341e072c54719"

--- a/.envrc.tpl
+++ b/.envrc.tpl
@@ -1,0 +1,30 @@
+# Load GPT credentials from 1Password
+export OPENAI_API_KEY="{{ op://Personal/GPT_CHINESE/credential }}"
+
+# Load Gemini credentials from 1Password
+export GEMINI_API_KEY="{{ op://Personal/GEMINI_API_KEY/credential }}"
+
+# Load ChatGLM credentials from 1Password
+export CHAT_GLM_API_KEY="{{ op://Personal/CHAT_GLM_API_KEY/credential }}"
+
+export DASHSCOPE_API_KEY="{{ op://Personal/DASHSCOPE_API_KEY_SINGAPORE/credential }}"
+
+export TENCENT_SECRET_ID="{{ op://Personal/TENCENT_ZH_LEARN/username }}"
+export TENCENT_API_KEY="{{ op://Personal/TENCENT_ZH_LEARN/credential }}"
+
+# Load DeepSeek credentials from 1Password
+export DEEPSEEK_API_KEY="{{ op://Personal/DEEPSEEK_API_KEY/credential }}"
+
+export AZURE_LANGUAGE_ENDPOINT="{{ op://Personal/AZURE_COGNITIVE_SERVICES/endpoint }}"
+export AZURE_LANGUAGE_KEY="{{ op://Personal/AZURE_COGNITIVE_SERVICES/credential }}"
+
+export FORVO_API_KEY="{{ op://Personal/FORVO_API_KEY/credential }}"
+
+export OPENROUTER_API_KEY="{{ op://Personal/OPENROUTER_API_KEY/credential }}"
+
+# Load MiniMax credentials from 1Password
+export MINIMAX_GROUP_ID="{{ op://Personal/MINIMAX_API_KEY/username }}"
+export MINIMAX_API_KEY="{{ op://Personal/MINIMAX_API_KEY/credential }}"
+
+# Load Google Custom Search API credentials from 1Password
+export GOOGLE_SEARCH_API_KEY="{{ op://Personal/GOOGLE_SEARCH_API_KEY/credential }}"


### PR DESCRIPTION
## Summary
- Replace 12 individual `op read` calls with a single `op inject` call using a template file
- Faster directory entry (one 1Password authentication instead of 12)
- Single permission prompt on macOS instead of 12 separate dialogs

## Test plan
- [x] Verified `direnv reload` works correctly
- [x] All environment variables are properly set

🤖 Generated with [Claude Code](https://claude.com/claude-code)