### PR TITLE
feat(tooling): add Java LSP plugin and fix module warnings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "enabledPlugins": {
+    "jdtls-lsp@claude-plugins-official": true
+  },
   "hooks": {
     "SessionStart": [
       {
@@ -11,14 +14,14 @@
         ]
       }
     ],
-    "Stop": [
+    "PostToolUse": [
       {
-        "matcher": "",
+        "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",
-            "command": "mvn spotless:apply",
-            "timeout": 30000
+            "command": "jq -r '.tool_input.file_path' | { read file_path; [[ \"$file_path\" == *.java ]] && mvn spotless:apply -q -DspotlessFiles=\"$file_path\" || true; }",
+            "timeout": 10000
           }
         ]
       }

--- a/zh-learn-application/src/main/java/module-info.java
+++ b/zh-learn-application/src/main/java/module-info.java
@@ -1,6 +1,6 @@
 module com.zhlearn.application {
-    requires com.zhlearn.domain;
-    requires com.zhlearn.infrastructure;
+    requires transitive com.zhlearn.domain;
+    requires transitive com.zhlearn.infrastructure;
     requires org.slf4j;
 
     exports com.zhlearn.application.service;

--- a/zh-learn-cli/src/main/java/com/zhlearn/cli/ApplicationContext.java
+++ b/zh-learn-cli/src/main/java/com/zhlearn/cli/ApplicationContext.java
@@ -105,10 +105,6 @@ public class ApplicationContext {
         return terminalFormatter;
     }
 
-    public ExamplesHtmlFormatter getExamplesHtmlFormatter() {
-        return examplesHtmlFormatter;
-    }
-
     public AnalysisPrinter getAnalysisPrinter() {
         return analysisPrinter;
     }
@@ -119,14 +115,6 @@ public class ApplicationContext {
 
     public AnkiExporter getAnkiExporter() {
         return ankiExporter;
-    }
-
-    public AudioPaths getAudioPaths() {
-        return audioPaths;
-    }
-
-    public AudioCache getAudioCache() {
-        return audioCache;
     }
 
     public PrePlayback getPrePlayback() {

--- a/zh-learn-cli/src/main/java/com/zhlearn/cli/MainCommand.java
+++ b/zh-learn-cli/src/main/java/com/zhlearn/cli/MainCommand.java
@@ -3,7 +3,6 @@ package com.zhlearn.cli;
 import java.util.List;
 
 import com.zhlearn.application.audio.AnkiMediaLocator;
-import com.zhlearn.application.format.ExamplesHtmlFormatter;
 import com.zhlearn.application.service.AnkiExporter;
 import com.zhlearn.cli.audio.PrePlayback;
 import com.zhlearn.domain.provider.AudioProvider;
@@ -14,9 +13,7 @@ import com.zhlearn.domain.provider.ExampleProvider;
 import com.zhlearn.domain.provider.ExplanationProvider;
 import com.zhlearn.domain.provider.PinyinProvider;
 import com.zhlearn.domain.provider.StructuralDecompositionProvider;
-import com.zhlearn.infrastructure.audio.AudioCache;
 import com.zhlearn.infrastructure.audio.AudioDownloadExecutor;
-import com.zhlearn.infrastructure.audio.AudioPaths;
 import com.zhlearn.infrastructure.common.AIProviderFactory;
 import com.zhlearn.infrastructure.dummy.DummyDefinitionProvider;
 import com.zhlearn.infrastructure.pinyin4j.Pinyin4jProvider;
@@ -44,11 +41,8 @@ public class MainCommand implements Runnable {
     private final List<AudioProvider> audioProviders;
     private final AudioDownloadExecutor audioExecutor;
     private final PrePlayback prePlayback;
-    private final AudioPaths audioPaths;
-    private final AudioCache audioCache;
     private final AIProviderFactory aiProviderFactory;
     private final TerminalFormatter terminalFormatter;
-    private final ExamplesHtmlFormatter examplesHtmlFormatter;
     private final AnalysisPrinter analysisPrinter;
     private final AnkiMediaLocator ankiMediaLocator;
     private final AnkiExporter ankiExporter;
@@ -68,12 +62,9 @@ public class MainCommand implements Runnable {
     public MainCommand(ApplicationContext context) {
         this(
                 context.getTerminalFormatter(),
-                context.getExamplesHtmlFormatter(),
                 context.getAnalysisPrinter(),
                 context.getAnkiMediaLocator(),
                 context.getAnkiExporter(),
-                context.getAudioPaths(),
-                context.getAudioCache(),
                 context.getPrePlayback(),
                 context.getAiProviderFactory(),
                 context.getAudioExecutor(),
@@ -85,24 +76,18 @@ public class MainCommand implements Runnable {
      */
     public MainCommand(
             TerminalFormatter terminalFormatter,
-            ExamplesHtmlFormatter examplesHtmlFormatter,
             AnalysisPrinter analysisPrinter,
             AnkiMediaLocator ankiMediaLocator,
             AnkiExporter ankiExporter,
-            AudioPaths audioPaths,
-            AudioCache audioCache,
             PrePlayback prePlayback,
             AIProviderFactory aiProviderFactory,
             AudioDownloadExecutor audioExecutor,
             List<AudioProvider> audioProviders) {
 
         this.terminalFormatter = terminalFormatter;
-        this.examplesHtmlFormatter = examplesHtmlFormatter;
         this.analysisPrinter = analysisPrinter;
         this.ankiMediaLocator = ankiMediaLocator;
         this.ankiExporter = ankiExporter;
-        this.audioPaths = audioPaths;
-        this.audioCache = audioCache;
         this.prePlayback = prePlayback;
         this.aiProviderFactory = aiProviderFactory;
         this.audioExecutor = audioExecutor;

--- a/zh-learn-cli/src/main/java/com/zhlearn/cli/TerminalFormatter.java
+++ b/zh-learn-cli/src/main/java/com/zhlearn/cli/TerminalFormatter.java
@@ -44,12 +44,9 @@ public class TerminalFormatter {
     private static class AnsiCodes {
         public static final String RESET = "\u001B[0m";
         public static final String BOLD = "\u001B[1m";
-        public static final String BOLD_OFF = "\u001B[22m";
         public static final String ITALIC = "\u001B[3m";
 
         // Colors
-        public static final String CYAN = "\u001B[36m";
-        public static final String YELLOW = "\u001B[33m";
         public static final String WHITE = "\u001B[37m";
         public static final String BRIGHT_WHITE = "\u001B[97m";
         public static final String MAGENTA = "\u001B[35m";

--- a/zh-learn-cli/src/main/java/module-info.java
+++ b/zh-learn-cli/src/main/java/module-info.java
@@ -21,6 +21,7 @@ module com.zhlearn.cli {
     uses com.zhlearn.domain.dictionary.Dictionary;
 
     exports com.zhlearn.cli;
+    exports com.zhlearn.cli.audio;
 
     opens com.zhlearn.cli to
             info.picocli;

--- a/zh-learn-cli/src/test/java/com/zhlearn/cli/AudioSelectionStepDefinitions.java
+++ b/zh-learn-cli/src/test/java/com/zhlearn/cli/AudioSelectionStepDefinitions.java
@@ -86,6 +86,8 @@ public class AudioSelectionStepDefinitions {
     private static class TestAudioPlayer implements AudioPlayer {
         int playCount = 0;
         Path lastPlayed;
+
+        @SuppressWarnings("unused") // tracked for potential future test assertions
         int stopCount = 0;
 
         @Override

--- a/zh-learn-infrastructure/pom.xml
+++ b/zh-learn-infrastructure/pom.xml
@@ -96,6 +96,20 @@
             <version>3.4.0</version>
         </dependency>
 
+        <!-- Gson - required by Tencent Cloud SDK internally -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
+
+        <!-- Kotlin stdlib - required by OkHttp (used by Tencent SDK) -->
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>1.9.22</version>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/zh-learn-infrastructure/src/main/java/module-info.java
+++ b/zh-learn-infrastructure/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 module com.zhlearn.infrastructure {
-    requires com.zhlearn.domain;
+    requires transitive com.zhlearn.domain;
     requires java.logging;
     requires java.net.http;
     requires java.sql;
@@ -26,7 +26,7 @@ module com.zhlearn.infrastructure {
     // Pinyin4j for Chinese to Pinyin conversion
     requires pinyin4j;
 
-    // Tencent Cloud SDK for TTS
+    // Tencent Cloud SDK for TTS (SDK uses Gson and OkHttp/Kotlin internally)
     requires tencentcloud.sdk.java.common;
     requires tencentcloud.sdk.java.tts;
     requires com.google.gson;

--- a/zh-learn-infrastructure/src/test/java/com/zhlearn/infrastructure/forvo/ForvoAudioProviderTest.java
+++ b/zh-learn-infrastructure/src/test/java/com/zhlearn/infrastructure/forvo/ForvoAudioProviderTest.java
@@ -31,6 +31,7 @@ class ForvoAudioProviderTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void returnsMultiplePronunciationsFromJson() throws Exception {
         HttpClient http = mock(HttpClient.class);
 
@@ -44,27 +45,23 @@ class ForvoAudioProviderTest {
                         + "  ]\n"
                         + "}";
 
-        @SuppressWarnings("unchecked")
         HttpResponse<String> resp1 = (HttpResponse<String>) mock(HttpResponse.class);
         when(resp1.statusCode()).thenReturn(200);
         when(resp1.body()).thenReturn(json);
 
-        @SuppressWarnings("unchecked")
         HttpResponse<byte[]> resp2 = (HttpResponse<byte[]>) mock(HttpResponse.class);
         when(resp2.statusCode()).thenReturn(200);
         when(resp2.body()).thenReturn(new byte[] {1});
 
-        @SuppressWarnings("unchecked")
         HttpResponse<byte[]> resp3 = (HttpResponse<byte[]>) mock(HttpResponse.class);
         when(resp3.statusCode()).thenReturn(200);
         when(resp3.body()).thenReturn(new byte[] {2});
 
-        @SuppressWarnings("unchecked")
         HttpResponse<byte[]> resp4 = (HttpResponse<byte[]>) mock(HttpResponse.class);
         when(resp4.statusCode()).thenReturn(200);
         when(resp4.body()).thenReturn(new byte[] {3});
 
-        // First call returns JSON; next three return mp3 bytes
+        // First call returns JSON; next three return mp3 bytes (raw types needed for Mockito)
         when(http.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
                 .thenReturn((HttpResponse) resp1)
                 .thenReturn((HttpResponse) resp2)


### PR DESCRIPTION
## Summary
- Enable jdtls-lsp plugin for Java language server support in Claude Code
- Add PostToolUse hook to auto-format Java files after edits (runs spotless on single file)
- Fix JPMS module warnings with `requires transitive` for domain types
- Add explicit Gson and Kotlin stdlib dependencies required by Tencent SDK
- Remove unused fields/getters and fix code warnings

## Changes
- `.claude/settings.json` - LSP plugin + auto-format hook
- `module-info.java` files - Add `requires transitive` for proper module exports
- `zh-learn-infrastructure/pom.xml` - Add Gson and Kotlin stdlib dependencies
- `MainCommand.java`, `ApplicationContext.java` - Remove unused fields/getters
- `TerminalFormatter.java` - Remove unused ANSI constants
- `ForvoAudioProviderTest.java` - Fix unchecked warnings

## Test plan
- [x] All unit tests pass (`mvn test`)
- [x] All e2e tests pass (`./run-e2e-tests.sh`)
- [x] Java LSP plugin working (can query symbols)
- [x] Auto-format hook tested on Java file edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)